### PR TITLE
Introduce LoadContext dataclass and make UnifiedStateLoader stateless

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -16,9 +16,9 @@
 =======
 ||||||| Common ancestor
   "lastRunAtMs": 1779680581651,
-  "turnsSinceLastRun": 5,
+  "turnsSinceLastRun": 8,
   "lastTranscriptMtimeMs": 1779680579992,
-  "lastProcessedGenerationId": "a93fe912-7d1b-4bc6-88a1-f2a5f6a45354",
+  "lastProcessedGenerationId": "8ece235b-54f3-4776-a4ab-89fcf91c1fec",
 =======
   "lastRunAtMs": 1779765051074,
   "turnsSinceLastRun": 2,


### PR DESCRIPTION
## Summary

Refactored `UnifiedStateLoader` to be stateless by introducing `LoadContext` and `LoadStats` dataclasses that encapsulate per-run state and statistics. This improves code maintainability and enables performance optimizations.

## Changes

- Introduced `LoadContext` dataclass to encapsulate per-run state and statistics
- Introduced `LoadStats` dataclass to track loading metrics
- Refactored `UnifiedStateLoader` pipeline methods to accept and return `LoadContext` instead of maintaining internal state
- Added per-run `address_cache` via `_resolve_address` on `LoadContext` to avoid repeated address resolution (P2-PERF-001)
- Consolidated state lookup so `_load_batch_indexes` returns a `state_code` and only a single `_resolve_state_record` is called (P2-PERF-002)
- Updated all tests for the new `LoadContext` API
- Fixed `TYPE_CHECKING` import in `tables.py` for `UnifiedReport`

## Type of change

- [x] Refactor (no behavior change)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #18 
- <kbd>&nbsp;1&nbsp;</kbd> #17 👈 
<!-- GitButler Footer Boundary Bottom -->

