### PR TITLE
remediation-r3-wave-2-task-2b-oklahoma-contribution-split

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pip-audit:
     runs-on: ubuntu-latest

--- a/app/abcs/abc_db_loader.py
+++ b/app/abcs/abc_db_loader.py
@@ -7,8 +7,9 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 
 import inject
-from app.logger import Logger
 from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.logger import Logger
 
 
 @dataclass

--- a/app/abcs/abc_db_loader.py
+++ b/app/abcs/abc_db_loader.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import abc
 import contextlib
 import itertools
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Iterator, List, Type
 
 import inject
 from app.logger import Logger
@@ -68,8 +68,8 @@ class DBLoaderClass(abc.ABC):
 
     @inject.autoparams()
     def remove_existing_records(self,
-                                records: List[SQLModel] | Iterator[SQLModel],
-                                validator: Type[SQLModel],
+                                records: list[SQLModel] | Iterator[SQLModel],
+                                validator: type[SQLModel],
                                 session: Session) -> Iterator[SQLModel]:
         """
         Check for existing data in the database.
@@ -92,12 +92,9 @@ class DBLoaderClass(abc.ABC):
         :param records: Iterable[SQLModel]
         :return: None
         """
-        try:
-            for record in records:
-                session.add(record)
-            session.commit()
-        except StopIteration:
-            self.logger.info("No records in iterator.")
+        for record in records:
+            session.add(record)
+        session.commit()
 
     @inject.autoparams()
     def add_with_limits(self, records: Iterator[SQLModel], limit: int, session: Session) -> None:

--- a/app/funcs/db_loader.py
+++ b/app/funcs/db_loader.py
@@ -5,8 +5,9 @@ import itertools
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass
 
-from app.logger import Logger
 from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.logger import Logger
 
 
 @contextlib.contextmanager

--- a/app/funcs/db_loader.py
+++ b/app/funcs/db_loader.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import itertools
+from collections.abc import Generator, Iterator
 from dataclasses import dataclass
-from typing import Generator, Iterator, List, Type
 
 from app.logger import Logger
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -50,8 +50,8 @@ class DBLoader:
         SQLModel.metadata.create_all(self.engine)
 
     def remove_existing_records(self,
-                                records: List[SQLModel] | Iterator[SQLModel],
-                                validator: Type[SQLModel]) -> Iterator[SQLModel]:
+                                records: list[SQLModel] | Iterator[SQLModel],
+                                validator: type[SQLModel]) -> Iterator[SQLModel]:
         """
         Check for existing data in the database.
         :param session:
@@ -73,13 +73,10 @@ class DBLoader:
         :param records: Iterable[SQLModel]
         :return: None
         """
-        try:
-            self.logger.info("Adding all records.")
-            for record in records:
-                session.add(record)
-            session.commit()
-        except StopIteration:
-            self.logger.info("No records in iterator.")
+        self.logger.info("Adding all records.")
+        for record in records:
+            session.add(record)
+        session.commit()
 
     def add_with_limits(self, records: Generator[SQLModel, None, None], limit: int, session: Session) -> None:
         """
@@ -100,7 +97,7 @@ class DBLoader:
             added_count += len(record_limit)
             self.logger.info(f"{added_count:,} records added")
 
-    def add(self, records: Iterator[SQLModel], record_type: Type[SQLModel], **kwargs) -> None:
+    def add(self, records: Iterator[SQLModel], record_type: type[SQLModel], **kwargs) -> None:
         """
         Add records to the database with optional limit.
         Uses add_all or add_with_limits.

--- a/app/states/texas/validators/texas_contributions.py
+++ b/app/states/texas/validators/texas_contributions.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime
-from typing import Optional
 
 from pydantic import field_validator, model_validator
 from pydantic_core import PydanticCustomError

--- a/app/states/texas/validators/texas_contributions.py
+++ b/app/states/texas/validators/texas_contributions.py
@@ -31,7 +31,7 @@ class TECContributionBase(CreateValidatorModel, TECSettings):
         ...,
         description="Date report received by TEC"
     )
-    infoOnlyFlag: Optional[bool] = Field(
+    infoOnlyFlag: bool | None = Field(
         default=None,
         description="Superseded by other report"
     )
@@ -59,105 +59,105 @@ class TECContributionBase(CreateValidatorModel, TECSettings):
         ...,
         description="Contribution amount"
     )
-    contributionDescr: Optional[str] = Field(
+    contributionDescr: str | None = Field(
         default=None,
         description="Contribution description"
     )
-    itemizeFlag: Optional[bool] = Field(
+    itemizeFlag: bool | None = Field(
         default=None,
         description="Y indicates that the contribution is itemized"
     )
-    travelFlag: Optional[bool] = Field(
+    travelFlag: bool | None = Field(
         default=None,
         description="Y indicates that the contribution has associated travel"
     )
     contributorPersentTypeCd: str = Field(...,
                                           description="Type of contributor name data - INDIVIDUAL or ENTITY"
                                           )
-    contributorNameOrganization: Optional[str] = Field(
+    contributorNameOrganization: str | None = Field(
         default=None,
         description="For ENTITY, the contributor organization name"
     )
-    contributorNameLast: Optional[str] = Field(
+    contributorNameLast: str | None = Field(
         default=None,
         description="For INDIVIDUAL, the contributor last name"
     )
-    contributorNameSuffixCd: Optional[str] = Field(
+    contributorNameSuffixCd: str | None = Field(
         default=None,
         description="For INDIVIDUAL, the contributor suffix"
     )
-    contributorNameFirst: Optional[str] = Field(
+    contributorNameFirst: str | None = Field(
         default=None,
         description="For INDIVIDUAL, the contributor first name"
     )
-    contributorNamePrefixCd: Optional[str] = Field(
+    contributorNamePrefixCd: str | None = Field(
         default=None,
         description="For INDIVIDUAL, the contributor prefix"
     )
-    contributorNameShort: Optional[str] = Field(
+    contributorNameShort: str | None = Field(
         default=None,
         description="For INDIVIDUAL, the contributor short name (nickname)"
     )
-    contributorNameFull: Optional[str] = Field(
+    contributorNameFull: str | None = Field(
         default=None,
         description="For INDIVIDUAL, the contributor full name"
     )
-    contributorStreetCity: Optional[str] = Field(
+    contributorStreetCity: str | None = Field(
         default=None,
         description="The contributor street address city"
     )
-    contributorStreetStateCd: Optional[str] = Field(
+    contributorStreetStateCd: str | None = Field(
         default=None,
         description="Contributor street address - state code (e.g. TX, CA) - for  \
      country=USA/UMI only"
     )
-    contributorStreetCountyCd: Optional[str] = Field(
+    contributorStreetCountyCd: str | None = Field(
         default=None,
         description="Contributor street address - Texas county")
-    contributorStreetCountryCd: Optional[str] = Field(
+    contributorStreetCountryCd: str | None = Field(
         default=None,
         description="Contributor street address - country (e.g. USA, UMI, MEX, CAN)"
     )
-    contributorStreetPostalCode: Optional[str] = Field(
+    contributorStreetPostalCode: str | None = Field(
         default=None,
         description="Contributor street address - postal code - for USA addresses only"
     )
-    contributorStreetRegion: Optional[str] = Field(
+    contributorStreetRegion: str | None = Field(
         default=None,
         description="Contributor street address - region for country other than USA"
     )
-    contributorEmployer: Optional[str] = Field(
+    contributorEmployer: str | None = Field(
         default=None,
         description="Contributor employer"
     )
-    contributorOccupation: Optional[str] = Field(
+    contributorOccupation: str | None = Field(
         default=None,
         description="Contributor occupation"
     )
-    contributorJobTitle: Optional[str] = Field(
+    contributorJobTitle: str | None = Field(
         default=None,
         description="Contributor job title"
     )
-    contributorPacFein: Optional[str] = Field(
+    contributorPacFein: str | None = Field(
         description="FEC ID of out-of-state PAC contributor",
     )
-    contributorOosPacFlag: Optional[bool] = Field(
+    contributorOosPacFlag: bool | None = Field(
         default=None,
         description="Indicates if contributor is an out-of-state PAC "
     )
-    contributorLawFirmName: Optional[str] = Field(
+    contributorLawFirmName: str | None = Field(
         default=None,
         description="Contributor law firm name"
     )
-    contributorSpouseLawFirmName: Optional[str] = Field(
+    contributorSpouseLawFirmName: str | None = Field(
         default=None,
         description="Contributor spouse law firm name"
     )
-    contributorParent1LawFirmName: Optional[str] = Field(
+    contributorParent1LawFirmName: str | None = Field(
         default=None,
         description="Contributor parent #1 law firm name"
     )
-    contributorParent2LawFirmName: Optional[str] = Field(
+    contributorParent2LawFirmName: str | None = Field(
         default=None,
         description="Contributor parent #2 law firm name"
     )
@@ -256,7 +256,7 @@ class TECContribution(TECContributionBase, table=True):
 
     __tablename__ = "tx_contributions"
     __table_args__ = {"schema": "texas"}
-    id: Optional[str] = Field(
+    id: str | None = Field(
         default=None,
         description="Unique identifier",
     )


### PR DESCRIPTION
## Summary

Remediation R3 Wave 2 Task 2B: Oklahoma contribution split refactoring with security and quality fixes.

## Changes

- Refactored `OklahomaContribution` validator into four-level hierarchy (Base/Create/Read/Table) with `extra='forbid'` to reject unknown CSV fields at ingestion
- Replaced `asyncio.run()` in `OnePasswordItem.__init__` with async factory pattern (`create()` / `create_sync()`) to prevent RuntimeError in event loops
- Fixed mutable singleton in processor: `get_builder()` now returns fresh `UnifiedSQLModelBuilder` instances instead of cached ones
- Modernized typing imports across codebase (Python 3.10+ builtins instead of `typing` module)
- Removed ~95 lines of commented-out validators and dead code
- Fixed `datetime.utcnow()` → `datetime.now(timezone.utc)` in spac.py
- Changed bare `except:` → `except Exception:` in legacy ABCs
- Fixed import ordering and trailing whitespace in Oklahoma validators
- Added least-privilege `contents: read` permissions to dependency-scan workflow
- Resolved merge conflict markers in ok_contribution imports

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #18 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #17 
<!-- GitButler Footer Boundary Bottom -->

