### PR TITLE
fix(resolve): merge a unified_entity with its source person/committee (cross-source dedup)

### DIFF
--- a/app/resolve/run.py
+++ b/app/resolve/run.py
@@ -84,10 +84,52 @@ def resolution_schema_table_names() -> frozenset[str]:
     return frozenset(model.__tablename__ for model in _resolution_schema_models())  # type: ignore[attr-defined]
 
 
+# Additive columns that ``create_all`` cannot add to a PRE-EXISTING table (no Alembic
+# in this project — idempotent DDL, mirroring unified_database's dedup-index approach).
+# Each entry is (table, column, full CREATE-safe ALTER statement). The statements are
+# constants (never interpolated) and INTEGER / VARCHAR are valid on both Postgres and
+# SQLite, so this is dialect-safe.
+_ADDITIVE_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    (
+        "resolution_input",
+        "linked_person_id",
+        "ALTER TABLE resolution_input ADD COLUMN linked_person_id INTEGER",
+    ),
+    (
+        "resolution_input",
+        "linked_committee_id",
+        "ALTER TABLE resolution_input ADD COLUMN linked_committee_id VARCHAR(128)",
+    ),
+)
+
+
+def _ensure_additive_columns(engine: Engine) -> None:
+    """Add columns that exist on the model but not yet on a pre-existing table.
+
+    Guarded by reflection so it is a no-op on a freshly ``create_all``-ed schema
+    (where the column already exists) — only an older table missing the column is
+    altered. Runs the same on Postgres and SQLite.
+    """
+    from sqlalchemy import inspect as sa_inspect
+    from sqlalchemy import text
+
+    inspector = sa_inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    for table, column, ddl in _ADDITIVE_COLUMNS:
+        if table not in existing_tables:
+            continue
+        if column in {col["name"] for col in inspector.get_columns(table)}:
+            continue
+        with engine.begin() as conn:
+            conn.execute(text(ddl))
+        logger.info("ensure_resolution_schema: added missing column %s.%s", table, column)
+
+
 def ensure_resolution_schema(engine: Engine) -> None:
     """Create only resolve-layer tables; never the full unified schema."""
     tables = [model.__table__ for model in _resolution_schema_models()]
     SQLModel.metadata.create_all(engine, tables=tables)
+    _ensure_additive_columns(engine)
 
 
 # Counter keys written to ``match_run`` by ``ResolutionRun.finish()``.

--- a/app/resolve/stages/fastpath.py
+++ b/app/resolve/stages/fastpath.py
@@ -180,6 +180,48 @@ def _collect_name_address_candidates(
     return candidates
 
 
+def _collect_entity_to_source_candidates(
+    rows: list[ResolutionInput],
+) -> list[_MergeCandidate]:
+    """Merge a ``unified_entity`` with the source record it 1:1-links to.
+
+    ``unified_entities.person_id`` / ``committee_id`` are unique FKs: an entity of
+    type 'person' IS the same real-world entity as the ``unified_person`` it points
+    to (same for committees).  Blocking cannot reliably pair them (the entity's name
+    is the full normalized name while the person's is first/last, so they often land
+    in different blocks), so this deterministic edge guarantees co-clustering — the
+    fix for near-zero cross-source dedup.
+    """
+    persons_by_id = {
+        row.source_id: row for row in rows if row.source_type == "unified_person"
+    }
+    committees_by_filer = {
+        row.source_id: row for row in rows if row.source_type == "unified_committee"
+    }
+    candidates: list[_MergeCandidate] = []
+    for row in rows:
+        if row.source_type != "unified_entity":
+            continue
+        target: ResolutionInput | None = None
+        rule = ""
+        if row.linked_person_id is not None:
+            target = persons_by_id.get(str(row.linked_person_id))
+            rule = "unified_entity_to_person_link"
+        elif row.linked_committee_id is not None:
+            target = committees_by_filer.get(str(row.linked_committee_id))
+            rule = "unified_entity_to_committee_link"
+        if target is not None:
+            candidates.append(
+                _MergeCandidate(
+                    left=_record_ref(row),
+                    right=_record_ref(target),
+                    method=MatchMethod.exact,
+                    rule=rule,
+                )
+            )
+    return candidates
+
+
 def _dedupe_candidates(candidates: list[_MergeCandidate]) -> list[_MergeCandidate]:
     seen_pairs: set[tuple[str, str, str, str]] = set()
     deduped: list[_MergeCandidate] = []
@@ -195,6 +237,7 @@ def _dedupe_candidates(candidates: list[_MergeCandidate]) -> list[_MergeCandidat
 
 def _collect_merge_candidates(rows: list[ResolutionInput]) -> list[_MergeCandidate]:
     ordered_rules = (
+        _collect_entity_to_source_candidates,  # deterministic 1:1 FK link — runs first
         _collect_filer_id_candidates,
         _collect_name_address_candidates,
     )

--- a/app/resolve/standardize/stage1.py
+++ b/app/resolve/standardize/stage1.py
@@ -199,6 +199,8 @@ def _collect_source_rows(session: Session, state_id: int) -> list[dict[str, Any]
             UnifiedEntity.id,
             UnifiedEntity.name,
             UnifiedEntity.entity_type,
+            UnifiedEntity.person_id,
+            UnifiedEntity.committee_id,
             UnifiedAddress.street_1,
             UnifiedAddress.street_2,
             UnifiedAddress.city,
@@ -260,6 +262,8 @@ def _collect_source_rows(session: Session, state_id: int) -> list[dict[str, Any]
                 "source_type": "unified_entity",
                 "source_id": str(row.id),
                 "entity_type": row.entity_type.value,
+                "linked_person_id": row.person_id,
+                "linked_committee_id": row.committee_id,
                 "raw_name": row.name or "",
                 "raw_address": _compose_raw_address(
                     row.street_1, row.street_2, row.city, row.state, row.zip_code
@@ -332,8 +336,16 @@ def _compute_features(rows: list[dict[str, Any]], run_id: int) -> list[Resolutio
     activity_dates = [
         (r.get("first_activity_date"), r.get("last_activity_date")) for r in rows
     ]
+    # Keep the deterministic link ids out of the Polars frame too (mixed None/int and
+    # None/str across source types); reattach by row index like the activity dates.
+    linked_ids = [
+        (r.get("linked_person_id"), r.get("linked_committee_id")) for r in rows
+    ]
+    _frame_skip = (
+        "first_activity_date", "last_activity_date", "linked_person_id", "linked_committee_id",
+    )
     frame_rows = [
-        {k: v for k, v in r.items() if k not in ("first_activity_date", "last_activity_date")}
+        {k: v for k, v in r.items() if k not in _frame_skip}
         for r in rows
     ]
     frame = pl.DataFrame(frame_rows)
@@ -363,6 +375,7 @@ def _compute_features(rows: list[dict[str, Any]], run_id: int) -> list[Resolutio
     staged: list[ResolutionInput] = []
     for idx, row in enumerate(enriched.iter_rows(named=True)):
         first_activity_date, last_activity_date = activity_dates[idx]
+        linked_person_id, linked_committee_id = linked_ids[idx]
         name_values = _name_fields(row["std_name"])
         address_values = _address_fields(row["std_address"])
         normalized_org = row["normalized_org"] or ""
@@ -380,6 +393,8 @@ def _compute_features(rows: list[dict[str, Any]], run_id: int) -> list[Resolutio
                 raw_address=row["raw_address"],
                 first_activity_date=first_activity_date,
                 last_activity_date=last_activity_date,
+                linked_person_id=linked_person_id,
+                linked_committee_id=linked_committee_id,
                 **name_values,
                 **address_values,
             )

--- a/app/resolve/standardize/staging.py
+++ b/app/resolve/standardize/staging.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 
-from sqlalchemy import Column, Date, String
+from sqlalchemy import Column, Date, Integer, String
 from sqlmodel import Field, SQLModel
 
 from app.resolve.models.canonical import map_unified_to_canonical_entity_type
@@ -37,6 +37,13 @@ class ResolutionInput(SQLModel, table=True):
         sa_column=Column(String(SOURCE_ID_MAX_LENGTH), nullable=False, index=True)
     )
     entity_type: str = Field(sa_column=Column(String(64), nullable=False, index=True))
+
+    # Deterministic 1:1 link carried from unified_entities so the fast path can merge a
+    # unified_entity with the source unified_person / unified_committee it represents
+    # (they are the same real-world entity). Null for unified_person / unified_committee
+    # source rows themselves.
+    linked_person_id: int | None = Field(default=None, sa_column=Column(Integer))
+    linked_committee_id: str | None = Field(default=None, sa_column=Column(String(128)))
 
     first_name: str | None = Field(default=None, sa_column=Column(String(200)))
     middle_name: str | None = Field(default=None, sa_column=Column(String(200)))

--- a/tests/resolve/test_fastpath.py
+++ b/tests/resolve/test_fastpath.py
@@ -299,3 +299,71 @@ def test_running_fastpath_twice_is_deterministic():
     assert sorted(map(decision_key, first_decisions)) == sorted(
         map(decision_key, second_decisions)
     )
+
+
+def _entity_row(
+    *,
+    run_id: int,
+    source_id: str,
+    entity_type: str = "person",
+    linked_person_id: int | None = None,
+    linked_committee_id: str | None = None,
+) -> ResolutionInput:
+    return ResolutionInput(
+        run_id=run_id,
+        source_type="unified_entity",
+        source_id=source_id,
+        entity_type=entity_type,
+        linked_person_id=linked_person_id,
+        linked_committee_id=linked_committee_id,
+        first_name="Jane" if entity_type == "person" else None,
+        last_name="Doe" if entity_type == "person" else None,
+        normalized_org=None if entity_type == "person" else "Friends of Texas",
+        parse_status="parsed",
+    )
+
+
+def test_unified_entity_merges_with_its_linked_person():
+    engine = _make_engine()
+    with Session(engine) as session:
+        _seed_run(session)
+        session.add(_person_row(run_id=1, source_id="42"))
+        session.add(_entity_row(run_id=1, source_id="900", linked_person_id=42))
+        session.commit()
+
+        result = run_fastpath_stage(session, run_id=1, config={})
+        assert result == {"auto_merges": 1}
+
+        edges = session.exec(select(MergeEdge).where(MergeEdge.run_id == 1)).all()
+        assert len(edges) == 1
+        pair = {
+            (edges[0].source_a_type, edges[0].source_a_id),
+            (edges[0].source_b_type, edges[0].source_b_id),
+        }
+        assert pair == {("unified_person", "42"), ("unified_entity", "900")}
+
+        decisions = session.exec(select(MatchDecision).where(MatchDecision.run_id == 1)).all()
+        assert json.loads(decisions[0].explanation_json)["rule"] == "unified_entity_to_person_link"
+
+
+def test_unified_entity_merges_with_its_linked_committee():
+    engine = _make_engine()
+    with Session(engine) as session:
+        _seed_run(session)
+        session.add(_committee_row(run_id=1, source_id="CMT-7"))
+        session.add(
+            _entity_row(
+                run_id=1, source_id="901", entity_type="committee", linked_committee_id="CMT-7"
+            )
+        )
+        session.commit()
+
+        result = run_fastpath_stage(session, run_id=1, config={})
+        assert result == {"auto_merges": 1}
+
+        edges = session.exec(select(MergeEdge).where(MergeEdge.run_id == 1)).all()
+        pair = {
+            (edges[0].source_a_type, edges[0].source_a_id),
+            (edges[0].source_b_type, edges[0].source_b_id),
+        }
+        assert pair == {("unified_committee", "CMT-7"), ("unified_entity", "901")}

--- a/tests/resolve/test_resolve_cli.py
+++ b/tests/resolve/test_resolve_cli.py
@@ -136,6 +136,25 @@ class TestEnsureResolutionSchema:
 
         engine.dispose()
 
+    def test_adds_missing_columns_to_existing_resolution_input(self):
+        """An older resolution_input (no linked_* cols) is migrated in place;
+        create_all alone cannot add columns to a pre-existing table."""
+        from sqlalchemy import text
+
+        engine = create_engine("sqlite:///:memory:", echo=False)
+        # Simulate a pre-existing table that lacks the new deterministic-link columns.
+        with engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE resolution_input (id INTEGER PRIMARY KEY, run_id INTEGER)")
+            )
+
+        ensure_resolution_schema(engine)
+
+        cols = {c["name"] for c in sa_inspect(engine).get_columns("resolution_input")}
+        assert "linked_person_id" in cols
+        assert "linked_committee_id" in cols
+        engine.dispose()
+
 
 class TestResolveStateCode:
     def test_texas_name_returns_TX(self):


### PR DESCRIPTION
## Summary
Fixes **near-zero cross-source dedup** in entity resolution: a `unified_entity` and the `unified_person`/`unified_committee` it 1:1-links to (`unified_entities.person_id` / `committee_id`) were never merged into one canonical entity, so every real person/committee produced **two** canonicals.

## Root cause
The resolver feeds all three source types into `resolution_input`, but the deterministic FK link was never carried through, and blocking can't pair them (the entity carries the full normalized name while the person carries first/last → different blocks). So cross-source dedup was ~0.

## Fix
- `resolution_input` now carries `linked_person_id` / `linked_committee_id` (stage1 loads them from `unified_entities`).
- A new deterministic fast-path rule emits `entity↔person` and `entity↔committee` merge edges (bypasses blocking, runs first); clustering co-locates them and survivorship emits **one** canonical_entity.
- `ensure_resolution_schema` **self-heals** the two columns on a pre-existing `resolution_input` (guarded, idempotent reflect→ALTER — no Alembic, dialect-safe) so the first real run needs no manual migration.

## Verification (TX data)
- **canonical_entity 125,182 → 62,127** (~50% collapse); **cross-source canonicals 0 → 61,823**.
- Concrete example — one canonical now merges a committee and its entity (`unified_committee 00010066` + `unified_entity 19372` → "Homero R. Lucero").
- Resolve suite **473 passed** (+2 fast-path tests); resolve-cli **40 passed** (+1 migration test); ruff clean. Change is additive/localized.

Surfaced while running the resolve passes over the ELT output in #22 (independent of that PR — applies to any data feeding resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)