### PR TITLE
fix(resolve): don't crash stage-1 on a dirty address (occupancy type without identifier)

### DIFF
--- a/app/resolve/standardize/addresses.py
+++ b/app/resolve/standardize/addresses.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import usaddress
 from scourgify import normalize_address_record
-from scourgify.exceptions import UnParseableAddressError
+from scourgify.exceptions import AddressNormalizationError, UnParseableAddressError
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,7 +78,10 @@ def standardize_address(
 
     try:
         normalized = normalize_address_record(address_text)
-    except (UnParseableAddressError, ValueError):
+    except (UnParseableAddressError, AddressNormalizationError, ValueError):
+        # Dirty government addresses (e.g. an "Apt" with no unit number) raise
+        # AddressNormalizationError; degrade to the usaddress fallback / unparsed
+        # rather than crashing the whole standardization stage.
         normalized = None
 
     if normalized:

--- a/tests/resolve/test_standardize.py
+++ b/tests/resolve/test_standardize.py
@@ -232,3 +232,18 @@ def test_build_resolution_input_rolls_back_delete_on_insert_failure(monkeypatch)
         assert len(surviving) == 1
         assert surviving[0].source_id == "legacy"
 
+
+
+@pytest.mark.parametrize(
+    "dirty",
+    [
+        "123 Main St Apt, Austin, TX 78701",   # occupancy type, no identifier
+        "500 W 2nd St Unit, Dallas TX",
+        "1 Plaza Fl, Houston, TX",
+    ],
+)
+def test_standardize_address_survives_dirty_occupancy(dirty):
+    """A scourgify AddressNormalizationError (occupancy type w/o identifier) must
+    degrade to a parsed/unparsed result, never propagate and kill stage 1."""
+    result = standardize_address(dirty)
+    assert result.parse_status in {"parsed", "partial", "unparsed"}


### PR DESCRIPTION
## Summary

Fixed stage-1 crash when encountering dirty addresses with occupancy types but no identifiers. The `standardize_address` function now catches `AddressNormalizationError` from scourgify in addition to existing exceptions, allowing graceful degradation to fallback parsing instead of aborting the entire standardization pass.

## Changes

- Added `AddressNormalizationError` exception handling in `standardize_address` to match existing `UnParseableAddressError` handling
- Dirty addresses now degrade to usaddress fallback/unparsed instead of crashing stage-1
- Added regression test covering three dirty occupancy-without-identifier addresses

## Type of change

- [x] Bug fix