### PR TITLE
Remediation W1: fix DEBT/TRVL data-loss + bulk upsert primitive

### DIFF
--- a/app/abcs/abc_db_loader.py
+++ b/app/abcs/abc_db_loader.py
@@ -4,11 +4,13 @@ import abc
 import contextlib
 import itertools
 from dataclasses import dataclass
-from typing import Iterator, List, Type
+from typing import Iterator, List, Optional, Type
 
 import inject
-from app.logger import Logger
 from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.core.upsert import bulk_upsert
+from app.logger import Logger
 
 
 @dataclass
@@ -66,17 +68,40 @@ class DBLoaderClass(abc.ABC):
         self.logger.info("Creating all tables")
         SQLModel.metadata.create_all(engine)
 
+    @staticmethod
+    def _pk_cols(model: Type[SQLModel]) -> List[str]:
+        """Return the primary-key column names for *model*.
+
+        Used internally to derive *conflict_cols* for :func:`bulk_upsert`.
+
+        Raises a clear ``TypeError`` if *model* is not a table-backed SQLModel
+        (``table=True``) — otherwise ``model.__table__`` would raise an opaque
+        ``AttributeError`` deep in the upsert path.
+        """
+        if not hasattr(model, "__table__"):
+            raise TypeError(
+                f"{getattr(model, '__name__', model)!r} is not a table-backed "
+                "SQLModel (no __table__); upsert needs a table=True model."
+            )
+        return [c.name for c in model.__table__.primary_key.columns]
+
     @inject.autoparams()
     def remove_existing_records(self,
                                 records: List[SQLModel] | Iterator[SQLModel],
                                 validator: Type[SQLModel],
                                 session: Session) -> Iterator[SQLModel]:
-        """
-        Check for existing data in the database.
-        :param session:
-        :param records:
-        :param validator: SQLModel
-        :return: Iterator[SQLModel]
+        """Check for existing data in the database and return only new records.
+
+        .. deprecated::
+            This method has **zero callers** in the current codebase and is
+            superseded by the DO UPDATE upsert path in :meth:`add` /
+            :meth:`add_all` / :meth:`add_with_limits`.  It is retained for
+            backward-compatibility but should not be used in new code.
+
+        :param session: active SQLModel session (injected)
+        :param records: iterable of SQLModel instances to filter
+        :param validator: SQLModel subclass whose ``.id`` column is queried
+        :return: Iterator[SQLModel] — records not already in the database
         """
         self.logger.info("Checking for existing data in the database")
         _existing_records = set(record.id for record in session.exec(select(validator.id)).all())
@@ -85,35 +110,77 @@ class DBLoaderClass(abc.ABC):
         return iter(remaining_records)
 
     @inject.autoparams()
-    def add_all(self, records: Iterator[SQLModel], session: Session) -> None:
-        """
-        Add all records to the database.
-        :param session:
-        :param records: Iterable[SQLModel]
+    def add_all(
+        self,
+        records: Iterator[SQLModel],
+        session: Session,
+        record_type: Optional[Type[SQLModel]] = None,
+    ) -> None:
+        """Add all records to the database using DO UPDATE upsert semantics.
+
+        Converts each SQLModel instance to a plain dict via ``model_dump()``
+        and delegates to :func:`~app.core.upsert.bulk_upsert` so that
+        re-inserted rows overwrite existing ones (amended TEC records are
+        handled correctly).
+
+        When *record_type* is not provided the model class is inferred from
+        the first record in the iterator.  If the iterator is empty the call
+        is a no-op.
+
+        :param session: active SQLModel session (injected)
+        :param records: iterable of SQLModel instances
+        :param record_type: optional model class; inferred from first record
+            when omitted
         :return: None
         """
-        try:
-            for record in records:
-                session.add(record)
-            session.commit()
-        except StopIteration:
+        record_list = list(records)
+        if not record_list:
             self.logger.info("No records in iterator.")
+            return
+
+        model = record_type if record_type is not None else type(record_list[0])
+        conflict_cols = self._pk_cols(model)
+        row_dicts = [r.model_dump() for r in record_list]
+        total = bulk_upsert(session, model, row_dicts, conflict_cols=conflict_cols)
+        self.logger.info(f"Upserted {total:,} records via add_all.")
 
     @inject.autoparams()
-    def add_with_limits(self, records: Iterator[SQLModel], limit: int, session: Session) -> None:
+    def add_with_limits(
+        self,
+        records: Iterator[SQLModel],
+        limit: int,
+        session: Session,
+        record_type: Optional[Type[SQLModel]] = None,
+    ) -> None:
+        """Add records in batches of *limit* using DO UPDATE upsert semantics.
+
+        Each batch is converted to dicts and forwarded to
+        :func:`~app.core.upsert.bulk_upsert`.  The model class is taken from
+        *record_type* when provided, otherwise inferred from the first record
+        in each batch.
+
+        :param session: active SQLModel session (injected)
+        :param records: iterable of SQLModel instances
+        :param limit: maximum records per batch
+        :param record_type: optional model class; inferred from first record
+            when omitted
+        :return: None
         """
-        Add all records with a limit.
-        :param session:
-        :param records: Iterable[SQLModel]
-        :param limit: int
-        :return:
-        """
+        records = iter(records)
+        model: Optional[Type[SQLModel]] = record_type
+
         while True:
             record_limit = list(itertools.islice(records, limit))
             if not record_limit:
                 break
-            session.add_all(record_limit)
-            session.commit()
+
+            if model is None:
+                model = type(record_limit[0])
+
+            conflict_cols = self._pk_cols(model)
+            row_dicts = [r.model_dump() for r in record_limit]
+            total = bulk_upsert(session, model, row_dicts, conflict_cols=conflict_cols)
+            self.logger.info(f"Upserted {total:,} records in batch (limit={limit:,}).")
 
     @inject.autoparams()
     def add(self, records: Iterator[SQLModel], record_type: SQLModel, session: Session, **kwargs) -> None:
@@ -134,10 +201,10 @@ class DBLoaderClass(abc.ABC):
 
         if _add_limit:
             self.logger.info(f"Adding {_type} records with limit of {_add_limit:,}.")
-            self.add_with_limits(records, _add_limit, session)
+            self.add_with_limits(records, _add_limit, session, record_type=record_type)
         else:
             self.logger.info(f"Adding all {_type} records.")
-            self.add_all(records, session)
+            self.add_all(records, session, record_type=record_type)
 
         self.logger.info(f"{_type} records added")
 

--- a/app/core/upsert.py
+++ b/app/core/upsert.py
@@ -1,0 +1,147 @@
+"""
+Dialect-aware bulk upsert helper (DO UPDATE).
+
+Supports SQLite and PostgreSQL via their respective SQLAlchemy dialect
+``insert`` constructs, both of which expose ``.on_conflict_do_update()``.
+
+Usage example::
+
+    from app.core.upsert import bulk_upsert
+
+    total = bulk_upsert(
+        session,
+        MyModel,
+        [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
+        conflict_cols=["id"],
+    )
+
+The function executes one ``INSERT … ON CONFLICT DO UPDATE`` statement per
+chunk and commits once after all chunks are processed.  Callers that wrap
+this in an outer transaction should manage the commit themselves — see the
+``commit_per_chunk`` parameter if per-chunk durability is required.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Type
+
+from sqlmodel import Session, SQLModel
+
+# Columns whose presence on the model should be excluded from the SET clause
+# because they represent immutable creation timestamps.
+_IMMUTABLE_COLS: frozenset[str] = frozenset({"created_at", "createdAt"})
+
+
+def _iter_chunks(
+    iterable: Iterable[Dict[str, Any]], chunk_size: int
+) -> Iterable[List[Dict[str, Any]]]:
+    """Yield successive *chunk_size*-sized lists from *iterable*."""
+    it = iter(iterable)
+    while True:
+        chunk = list(itertools.islice(it, chunk_size))
+        if not chunk:
+            break
+        yield chunk
+
+
+def bulk_upsert(
+    session: Session,
+    model: Type[SQLModel],
+    rows: Iterable[Dict[str, Any]],
+    *,
+    conflict_cols: Sequence[str],
+    update_cols: Optional[Sequence[str]] = None,
+    chunk_size: int = 5_000,
+    commit_per_chunk: bool = False,
+) -> int:
+    """Insert *rows* into *model*'s table, updating on conflict.
+
+    Parameters
+    ----------
+    session:
+        An active SQLModel/SQLAlchemy ``Session``.
+    model:
+        The SQLModel table class (must have ``__table__``).
+    rows:
+        An iterable of plain ``dict`` objects whose keys match model columns.
+        The iterable is consumed lazily in *chunk_size* batches.
+    conflict_cols:
+        Column name(s) that identify a conflict (typically the primary key).
+    update_cols:
+        Column name(s) to update on conflict.  ``None`` (default) updates
+        *all* columns except those listed in *conflict_cols* and any column
+        whose name appears in the immutable-column set
+        ``{"created_at", "createdAt"}``.
+    chunk_size:
+        Number of rows per ``INSERT`` statement.  Defaults to 5 000.
+    commit_per_chunk:
+        When ``True``, commits after every chunk instead of once at the end.
+        Use when you need partial-load durability on very large datasets.
+
+    Returns
+    -------
+    int
+        Total number of rows processed (sum of all chunk sizes).
+
+    Raises
+    ------
+    ValueError
+        If the database dialect is not ``sqlite`` or ``postgresql``.
+    """
+    dialect_name: str = session.get_bind().dialect.name
+
+    if dialect_name == "sqlite":
+        from sqlalchemy.dialects.sqlite import insert as _insert
+    elif dialect_name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as _insert
+    else:
+        raise ValueError(
+            f"bulk_upsert: unsupported dialect '{dialect_name}'. "
+            "Only 'sqlite' and 'postgresql' are supported."
+        )
+
+    table = model.__table__
+
+    # Build the set_ mapping once (reused for every chunk).
+    if update_cols is not None:
+        _update_col_names: Sequence[str] = update_cols
+    else:
+        conflict_set = set(conflict_cols)
+        model_col_names = {c.name for c in table.columns}
+        _update_col_names = [
+            name
+            for name in model_col_names
+            if name not in conflict_set and name not in _IMMUTABLE_COLS
+        ]
+
+    total_rows = 0
+
+    for chunk in _iter_chunks(rows, chunk_size):
+        if not chunk:
+            continue
+
+        insert_stmt = _insert(table).values(chunk)
+
+        # Build set_ from excluded pseudo-table so values reference the
+        # incoming row, not a static literal.
+        set_mapping: Dict[str, Any] = {
+            col_name: getattr(insert_stmt.excluded, col_name)
+            for col_name in _update_col_names
+        }
+
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=list(conflict_cols),
+            set_=set_mapping,
+        )
+
+        session.exec(upsert_stmt)  # type: ignore[arg-type]
+        total_rows += len(chunk)
+
+        if commit_per_chunk:
+            session.commit()
+
+    if not commit_per_chunk:
+        session.commit()
+
+    return total_rows

--- a/app/states/texas/validators/texas_debtdata.py
+++ b/app/states/texas/validators/texas_debtdata.py
@@ -1,3 +1,13 @@
+"""Texas TEC DEBT record validator.
+
+The TEC debt file (debts_YYYYMMDD.csv) carries 89 columns: a report header,
+lender identity (INDIVIDUAL or ENTITY), lender address, and five optional
+guarantor blocks (13 fields each).
+
+There are NO amount, interest-rate, or balance fields in the TEC debt CSV —
+those are intentionally absent from this model.
+"""
+
 from datetime import date
 from typing import Optional
 
@@ -12,74 +22,290 @@ class DebtData(TECSettings, table=True):
     __tablename__ = "tx_debt_data"
     __table_args__ = {"schema": "texas"}
 
+    # ── Ingestion metadata (snake_case, kept exactly as before) ──────────
     id: Optional[str] = Field(default=None, description="Unique record ID")
-    record_type: str = Field(..., max_length=20, description="Record type code - always DEBT")
-    form_type_cd: str = Field(..., max_length=20, description="TEC form used")
-    sched_form_type_cd: str = Field(..., max_length=20, description="TEC Schedule Used")
-    report_info_ident: int = Field(..., description="Unique report #")
-    received_dt: date = Field(..., description="Date report received by TEC")
+
+    # ── Report header ─────────────────────────────────────────────────────
+    recordType: str = Field(..., max_length=20, description="Record type code - always DEBT")
+    formTypeCd: str = Field(..., max_length=20, description="TEC form used")
+    schedFormTypeCd: str = Field(..., max_length=20, description="TEC Schedule Used")
+    reportInfoIdent: int = Field(..., description="Unique report #")
+    receivedDt: date = Field(..., description="Date report received by TEC")
     # Optional because some rows omit the flag entirely
-    info_only_flag: Optional[bool] = Field(default=None, description="Superseded by other report")
-    filer_ident: str = Field(..., max_length=100, description="Filer account #")
-    filer_type_cd: str = Field(..., max_length=30, description="Type of filer")
-    filer_name: str = Field(..., max_length=200, description="Filer name")
-    loan_info_id: int = Field(..., description="Loan unique identifier", primary_key=True)
+    infoOnlyFlag: Optional[bool] = Field(default=None, description="Superseded by other report")
+
+    # ── Filer ─────────────────────────────────────────────────────────────
+    filerIdent: str = Field(..., max_length=100, description="Filer account #")
+    filerTypeCd: str = Field(..., max_length=30, description="Type of filer")
+    filerName: str = Field(..., max_length=200, description="Filer name")
+
+    # ── Loan record ───────────────────────────────────────────────────────
+    loanInfoId: int = Field(
+        ..., description="Loan unique identifier", primary_key=True
+    )
     # Optional because rows may omit the guarantee flag
-    loan_guaranteed_flag: Optional[bool] = Field(
+    loanGuaranteedFlag: Optional[bool] = Field(
         default=None, description="Loan guaranteed indicator"
     )
-    lender_persent_type_cd: str = Field(
+
+    # ── Lender identity ───────────────────────────────────────────────────
+    lenderPersentTypeCd: str = Field(
         ..., max_length=30, description="Type of lender name data - INDIVIDUAL or ENTITY"
     )
 
-    # ── Name fields: only one group is required, depending on lender type ─────
-    # ENTITY rows: lender_name_organization required; individual fields optional
-    lender_name_organization: Optional[str] = Field(
+    # ENTITY rows: lenderNameOrganization required; individual fields optional
+    lenderNameOrganization: Optional[str] = Field(
         default=None, max_length=100, description="For ENTITY, the lender organization name"
     )
     # INDIVIDUAL rows: last + first required; rest optional
-    lender_name_last: Optional[str] = Field(
+    lenderNameLast: Optional[str] = Field(
         default=None, max_length=100, description="For INDIVIDUAL, the lender last name"
     )
-    lender_name_suffix_cd: Optional[str] = Field(
+    lenderNameSuffixCd: Optional[str] = Field(
         default=None, max_length=30, description="For INDIVIDUAL, the lender name suffix"
     )
-    lender_name_first: Optional[str] = Field(
+    lenderNameFirst: Optional[str] = Field(
         default=None, max_length=45, description="For INDIVIDUAL, the lender first name"
     )
-    lender_name_prefix_cd: Optional[str] = Field(
+    lenderNamePrefixCd: Optional[str] = Field(
         default=None, max_length=30, description="For INDIVIDUAL, the lender name prefix"
     )
-    lender_name_short: Optional[str] = Field(
+    lenderNameShort: Optional[str] = Field(
         default=None, max_length=25, description="For INDIVIDUAL, the lender short name"
     )
 
-    # ── Address fields: city and country are the minimum required ─────────────
-    lender_street_city: Optional[str] = Field(
+    # ── Lender address ────────────────────────────────────────────────────
+    lenderStreetCity: Optional[str] = Field(
         default=None, max_length=30, description="Lender street address - city"
     )
-    lender_street_state_cd: Optional[str] = Field(
+    lenderStreetStateCd: Optional[str] = Field(
         default=None,
         max_length=2,
         description="Lender street address - state code (for country=USA/UMI only)",
     )
-    lender_street_county_cd: Optional[str] = Field(
+    lenderStreetCountyCd: Optional[str] = Field(
         default=None, max_length=5, description="Lender street address - Texas county"
     )
-    lender_street_country_cd: Optional[str] = Field(
+    lenderStreetCountryCd: Optional[str] = Field(
         default=None,
         max_length=3,
         description="Lender street address - country (e.g. USA, UMI, MEX, CAN)",
     )
-    lender_street_postal_code: Optional[str] = Field(
+    lenderStreetPostalCode: Optional[str] = Field(
         default=None, max_length=20, description="Lender street address - postal code"
     )
-    lender_street_region: Optional[str] = Field(
+    lenderStreetRegion: Optional[str] = Field(
         default=None,
         max_length=30,
         description="Lender street address - region for country other than USA",
     )
 
+    # ── Guarantor block 1 (13 fields) ─────────────────────────────────────
+    guarantorPersentTypeCd1: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 1: type of name data"
+    )
+    guarantorNameOrganization1: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 1: organization name"
+    )
+    guarantorNameLast1: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 1: last name"
+    )
+    guarantorNameSuffixCd1: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 1: name suffix"
+    )
+    guarantorNameFirst1: Optional[str] = Field(
+        default=None, max_length=45, description="Guarantor 1: first name"
+    )
+    guarantorNamePrefixCd1: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 1: name prefix"
+    )
+    guarantorNameShort1: Optional[str] = Field(
+        default=None, max_length=25, description="Guarantor 1: short name"
+    )
+    guarantorStreetCity1: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 1: street city"
+    )
+    guarantorStreetStateCd1: Optional[str] = Field(
+        default=None, max_length=2, description="Guarantor 1: state code"
+    )
+    guarantorStreetCountyCd1: Optional[str] = Field(
+        default=None, max_length=5, description="Guarantor 1: county code"
+    )
+    guarantorStreetCountryCd1: Optional[str] = Field(
+        default=None, max_length=3, description="Guarantor 1: country code"
+    )
+    guarantorStreetPostalCode1: Optional[str] = Field(
+        default=None, max_length=20, description="Guarantor 1: postal code"
+    )
+    guarantorStreetRegion1: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 1: region"
+    )
+
+    # ── Guarantor block 2 (13 fields) ─────────────────────────────────────
+    guarantorPersentTypeCd2: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 2: type of name data"
+    )
+    guarantorNameOrganization2: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 2: organization name"
+    )
+    guarantorNameLast2: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 2: last name"
+    )
+    guarantorNameSuffixCd2: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 2: name suffix"
+    )
+    guarantorNameFirst2: Optional[str] = Field(
+        default=None, max_length=45, description="Guarantor 2: first name"
+    )
+    guarantorNamePrefixCd2: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 2: name prefix"
+    )
+    guarantorNameShort2: Optional[str] = Field(
+        default=None, max_length=25, description="Guarantor 2: short name"
+    )
+    guarantorStreetCity2: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 2: street city"
+    )
+    guarantorStreetStateCd2: Optional[str] = Field(
+        default=None, max_length=2, description="Guarantor 2: state code"
+    )
+    guarantorStreetCountyCd2: Optional[str] = Field(
+        default=None, max_length=5, description="Guarantor 2: county code"
+    )
+    guarantorStreetCountryCd2: Optional[str] = Field(
+        default=None, max_length=3, description="Guarantor 2: country code"
+    )
+    guarantorStreetPostalCode2: Optional[str] = Field(
+        default=None, max_length=20, description="Guarantor 2: postal code"
+    )
+    guarantorStreetRegion2: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 2: region"
+    )
+
+    # ── Guarantor block 3 (13 fields) ─────────────────────────────────────
+    guarantorPersentTypeCd3: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 3: type of name data"
+    )
+    guarantorNameOrganization3: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 3: organization name"
+    )
+    guarantorNameLast3: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 3: last name"
+    )
+    guarantorNameSuffixCd3: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 3: name suffix"
+    )
+    guarantorNameFirst3: Optional[str] = Field(
+        default=None, max_length=45, description="Guarantor 3: first name"
+    )
+    guarantorNamePrefixCd3: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 3: name prefix"
+    )
+    guarantorNameShort3: Optional[str] = Field(
+        default=None, max_length=25, description="Guarantor 3: short name"
+    )
+    guarantorStreetCity3: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 3: street city"
+    )
+    guarantorStreetStateCd3: Optional[str] = Field(
+        default=None, max_length=2, description="Guarantor 3: state code"
+    )
+    guarantorStreetCountyCd3: Optional[str] = Field(
+        default=None, max_length=5, description="Guarantor 3: county code"
+    )
+    guarantorStreetCountryCd3: Optional[str] = Field(
+        default=None, max_length=3, description="Guarantor 3: country code"
+    )
+    guarantorStreetPostalCode3: Optional[str] = Field(
+        default=None, max_length=20, description="Guarantor 3: postal code"
+    )
+    guarantorStreetRegion3: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 3: region"
+    )
+
+    # ── Guarantor block 4 (13 fields) ─────────────────────────────────────
+    guarantorPersentTypeCd4: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 4: type of name data"
+    )
+    guarantorNameOrganization4: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 4: organization name"
+    )
+    guarantorNameLast4: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 4: last name"
+    )
+    guarantorNameSuffixCd4: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 4: name suffix"
+    )
+    guarantorNameFirst4: Optional[str] = Field(
+        default=None, max_length=45, description="Guarantor 4: first name"
+    )
+    guarantorNamePrefixCd4: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 4: name prefix"
+    )
+    guarantorNameShort4: Optional[str] = Field(
+        default=None, max_length=25, description="Guarantor 4: short name"
+    )
+    guarantorStreetCity4: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 4: street city"
+    )
+    guarantorStreetStateCd4: Optional[str] = Field(
+        default=None, max_length=2, description="Guarantor 4: state code"
+    )
+    guarantorStreetCountyCd4: Optional[str] = Field(
+        default=None, max_length=5, description="Guarantor 4: county code"
+    )
+    guarantorStreetCountryCd4: Optional[str] = Field(
+        default=None, max_length=3, description="Guarantor 4: country code"
+    )
+    guarantorStreetPostalCode4: Optional[str] = Field(
+        default=None, max_length=20, description="Guarantor 4: postal code"
+    )
+    guarantorStreetRegion4: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 4: region"
+    )
+
+    # ── Guarantor block 5 (13 fields) ─────────────────────────────────────
+    guarantorPersentTypeCd5: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 5: type of name data"
+    )
+    guarantorNameOrganization5: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 5: organization name"
+    )
+    guarantorNameLast5: Optional[str] = Field(
+        default=None, max_length=100, description="Guarantor 5: last name"
+    )
+    guarantorNameSuffixCd5: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 5: name suffix"
+    )
+    guarantorNameFirst5: Optional[str] = Field(
+        default=None, max_length=45, description="Guarantor 5: first name"
+    )
+    guarantorNamePrefixCd5: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 5: name prefix"
+    )
+    guarantorNameShort5: Optional[str] = Field(
+        default=None, max_length=25, description="Guarantor 5: short name"
+    )
+    guarantorStreetCity5: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 5: street city"
+    )
+    guarantorStreetStateCd5: Optional[str] = Field(
+        default=None, max_length=2, description="Guarantor 5: state code"
+    )
+    guarantorStreetCountyCd5: Optional[str] = Field(
+        default=None, max_length=5, description="Guarantor 5: county code"
+    )
+    guarantorStreetCountryCd5: Optional[str] = Field(
+        default=None, max_length=3, description="Guarantor 5: country code"
+    )
+    guarantorStreetPostalCode5: Optional[str] = Field(
+        default=None, max_length=20, description="Guarantor 5: postal code"
+    )
+    guarantorStreetRegion5: Optional[str] = Field(
+        default=None, max_length=30, description="Guarantor 5: region"
+    )
+
+    # ── Ingestion metadata (snake_case, kept exactly as before) ──────────
     file_origin: str = Field(..., description="File origin", max_length=64)
     download_date: date = Field(..., description="Date file downloaded")
 
@@ -91,13 +317,14 @@ class DebtData(TECSettings, table=True):
     @model_validator(mode="before")
     @classmethod
     def check_lender_type(cls, values: dict) -> dict:
-        if values.get("lender_persent_type_cd") not in ("INDIVIDUAL", "ENTITY"):
+        lender_type = values.get("lenderPersentTypeCd")
+        if lender_type not in ("INDIVIDUAL", "ENTITY"):
             raise PydanticCustomError(
                 "lender_type",
                 "Lender type must be INDIVIDUAL or ENTITY",
                 {
-                    "column": "lender_persent_type_cd",
-                    "value": values.get("lender_persent_type_cd"),
+                    "column": "lenderPersentTypeCd",
+                    "value": lender_type,
                 },
             )
         return values
@@ -105,23 +332,23 @@ class DebtData(TECSettings, table=True):
     @model_validator(mode="before")
     @classmethod
     def check_individual_lender_info_filled(cls, values: dict) -> dict:
-        if values.get("lender_persent_type_cd") == "INDIVIDUAL":
-            if not values.get("lender_name_last") or not values.get("lender_name_first"):
+        if values.get("lenderPersentTypeCd") == "INDIVIDUAL":
+            if not values.get("lenderNameLast") or not values.get("lenderNameFirst"):
                 raise PydanticCustomError(
                     "individual_lender_info",
                     "For INDIVIDUAL lender, last name and first name must be provided",
-                    {"column": "lender_persent_type_cd", "value": "INDIVIDUAL"},
+                    {"column": "lenderPersentTypeCd", "value": "INDIVIDUAL"},
                 )
         return values
 
     @model_validator(mode="before")
     @classmethod
     def check_entity_lender_info_filled(cls, values: dict) -> dict:
-        if values.get("lender_persent_type_cd") == "ENTITY":
-            if not values.get("lender_name_organization"):
+        if values.get("lenderPersentTypeCd") == "ENTITY":
+            if not values.get("lenderNameOrganization"):
                 raise PydanticCustomError(
                     "entity_lender_info",
                     "For ENTITY lender, organization name must be provided",
-                    {"column": "lender_persent_type_cd", "value": "ENTITY"},
+                    {"column": "lenderPersentTypeCd", "value": "ENTITY"},
                 )
         return values

--- a/app/states/texas/validators/texas_traveldata.py
+++ b/app/states/texas/validators/texas_traveldata.py
@@ -1,13 +1,14 @@
 from datetime import date, datetime
 from typing import Optional
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import field_validator, model_validator
 from pydantic_core import PydanticCustomError
+from sqlmodel import Field
 
 from .texas_settings import TECSettings
 
 
-class TECTravelData(TECSettings):
+class TECTravelData(TECSettings, table=True):
     __tablename__ = "tx_travel_data"
     __table_args__ = {"schema": "texas"}
 

--- a/app/tests/test_debt_validator.py
+++ b/app/tests/test_debt_validator.py
@@ -1,0 +1,351 @@
+"""Tests for DebtData camelCase validator with guarantor blocks.
+
+Tests construct DebtData via model_validate — no DB connection required.
+All field keys match TEC CSV headers exactly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.states.texas.validators.texas_debtdata import DebtData
+
+# ---------------------------------------------------------------------------
+# Shared base data — only fields common to both lender types
+# ---------------------------------------------------------------------------
+
+BASE = {
+    "recordType": "DEBT",
+    "formTypeCd": "COH",
+    "schedFormTypeCd": "DEBT",
+    "reportInfoIdent": 123456,
+    "receivedDt": "20240315",  # TEC YYYYMMDD format (parsed by validate_dates)
+    "infoOnlyFlag": None,
+    "filerIdent": "00123456",
+    "filerTypeCd": "COH",
+    "filerName": "SMITH FOR SENATE",
+    "loanInfoId": 9900001,
+    "loanGuaranteedFlag": None,
+    # address (optional but commonly present)
+    "lenderStreetCity": "AUSTIN",
+    "lenderStreetStateCd": "TX",
+    "lenderStreetCountyCd": "453",
+    "lenderStreetCountryCd": "USA",
+    "lenderStreetPostalCode": "78701",
+    "lenderStreetRegion": None,
+    # ingestion metadata
+    "file_origin": "debts_20240315.csv",
+    "download_date": "2024-03-15",
+}
+
+
+def _individual_row(**overrides) -> dict:
+    """Build a valid INDIVIDUAL lender row."""
+    row = {
+        **BASE,
+        "lenderPersentTypeCd": "INDIVIDUAL",
+        "lenderNameLast": "DOE",
+        "lenderNameFirst": "JOHN",
+        "lenderNameSuffixCd": None,
+        "lenderNamePrefixCd": None,
+        "lenderNameShort": None,
+        "lenderNameOrganization": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _entity_row(**overrides) -> dict:
+    """Build a valid ENTITY lender row."""
+    row = {
+        **BASE,
+        "lenderPersentTypeCd": "ENTITY",
+        "lenderNameOrganization": "ACME FINANCIAL LLC",
+        "lenderNameLast": None,
+        "lenderNameFirst": None,
+        "lenderNameSuffixCd": None,
+        "lenderNamePrefixCd": None,
+        "lenderNameShort": None,
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidIndividualLender:
+    def test_validates_successfully(self):
+        debt = DebtData.model_validate(_individual_row())
+        assert debt.loanInfoId == 9900001
+        assert debt.lenderPersentTypeCd == "INDIVIDUAL"
+        assert debt.lenderNameLast == "DOE"
+        assert debt.lenderNameFirst == "JOHN"
+
+    def test_record_type_uppercased(self):
+        debt = DebtData.model_validate(_individual_row(recordType="debt"))
+        assert debt.recordType == "DEBT"
+
+    def test_filer_name_uppercased(self):
+        debt = DebtData.model_validate(_individual_row(filerName="Smith for Senate"))
+        assert debt.filerName == "SMITH FOR SENATE"
+
+    def test_blank_strings_cleared_to_none(self):
+        debt = DebtData.model_validate(_individual_row(lenderNameSuffixCd=""))
+        assert debt.lenderNameSuffixCd is None
+
+    def test_null_string_cleared_to_none(self):
+        debt = DebtData.model_validate(_individual_row(lenderStreetRegion="null"))
+        assert debt.lenderStreetRegion is None
+
+    def test_ingestion_fields_preserved(self):
+        debt = DebtData.model_validate(_individual_row())
+        assert debt.file_origin == "DEBTS_20240315.CSV"
+        assert str(debt.download_date) == "2024-03-15"
+
+    def test_id_defaults_to_none(self):
+        debt = DebtData.model_validate(_individual_row())
+        assert debt.id is None
+
+    def test_id_can_be_set(self):
+        debt = DebtData.model_validate(_individual_row(id="abc123"))
+        assert debt.id == "ABC123"
+
+
+class TestValidEntityLender:
+    def test_validates_successfully(self):
+        debt = DebtData.model_validate(_entity_row())
+        assert debt.lenderPersentTypeCd == "ENTITY"
+        assert debt.lenderNameOrganization == "ACME FINANCIAL LLC"
+
+    def test_individual_name_fields_absent(self):
+        debt = DebtData.model_validate(_entity_row())
+        assert debt.lenderNameLast is None
+        assert debt.lenderNameFirst is None
+
+
+# ---------------------------------------------------------------------------
+# Validation-error tests
+# ---------------------------------------------------------------------------
+
+
+class TestIndividualMissingNames:
+    def test_missing_last_name_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_individual_row(lenderNameLast=None))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "individual_lender_info" for e in errors)
+
+    def test_missing_first_name_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_individual_row(lenderNameFirst=None))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "individual_lender_info" for e in errors)
+
+    def test_blank_last_name_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_individual_row(lenderNameLast=""))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "individual_lender_info" for e in errors)
+
+    def test_blank_first_name_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_individual_row(lenderNameFirst=""))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "individual_lender_info" for e in errors)
+
+
+class TestEntityMissingOrganization:
+    def test_missing_organization_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_entity_row(lenderNameOrganization=None))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "entity_lender_info" for e in errors)
+
+    def test_blank_organization_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_entity_row(lenderNameOrganization=""))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "entity_lender_info" for e in errors)
+
+
+class TestInvalidLenderType:
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_individual_row(lenderPersentTypeCd="UNKNOWN"))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "lender_type" for e in errors)
+
+    def test_none_type_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DebtData.model_validate(_individual_row(lenderPersentTypeCd=None))
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "lender_type" for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Guarantor block round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestGuarantorBlock1:
+    def test_guarantor1_fields_round_trip(self):
+        row = _individual_row(
+            guarantorPersentTypeCd1="INDIVIDUAL",
+            guarantorNameLast1="JONES",
+            guarantorNameFirst1="MARY",
+            guarantorNameSuffixCd1=None,
+            guarantorNamePrefixCd1=None,
+            guarantorNameShort1=None,
+            guarantorNameOrganization1=None,
+            guarantorStreetCity1="DALLAS",
+            guarantorStreetStateCd1="TX",
+            guarantorStreetCountyCd1="113",
+            guarantorStreetCountryCd1="USA",
+            guarantorStreetPostalCode1="75201",
+            guarantorStreetRegion1=None,
+        )
+        debt = DebtData.model_validate(row)
+        assert debt.guarantorPersentTypeCd1 == "INDIVIDUAL"
+        assert debt.guarantorNameLast1 == "JONES"
+        assert debt.guarantorNameFirst1 == "MARY"
+        assert debt.guarantorStreetCity1 == "DALLAS"
+        assert debt.guarantorStreetStateCd1 == "TX"
+        assert debt.guarantorStreetCountryCd1 == "USA"
+        assert debt.guarantorStreetPostalCode1 == "75201"
+        assert debt.guarantorStreetRegion1 is None
+
+    def test_guarantor1_defaults_to_none_when_absent(self):
+        debt = DebtData.model_validate(_individual_row())
+        assert debt.guarantorPersentTypeCd1 is None
+        assert debt.guarantorNameLast1 is None
+        assert debt.guarantorNameOrganization1 is None
+        assert debt.guarantorStreetCity1 is None
+
+    def test_guarantor1_blank_string_cleared(self):
+        debt = DebtData.model_validate(_individual_row(guarantorStreetRegion1=""))
+        assert debt.guarantorStreetRegion1 is None
+
+
+class TestGuarantorBlock2:
+    def test_guarantor2_fields_round_trip(self):
+        row = _individual_row(
+            guarantorPersentTypeCd2="ENTITY",
+            guarantorNameOrganization2="GUARANTEE CORP",
+            guarantorStreetCity2="HOUSTON",
+            guarantorStreetCountryCd2="USA",
+        )
+        debt = DebtData.model_validate(row)
+        assert debt.guarantorPersentTypeCd2 == "ENTITY"
+        assert debt.guarantorNameOrganization2 == "GUARANTEE CORP"
+        assert debt.guarantorStreetCity2 == "HOUSTON"
+
+
+class TestGuarantorBlock3:
+    def test_guarantor3_fields_default_none(self):
+        debt = DebtData.model_validate(_individual_row())
+        assert debt.guarantorNameLast3 is None
+        assert debt.guarantorStreetCity3 is None
+
+    def test_guarantor3_fields_set(self):
+        debt = DebtData.model_validate(
+            _individual_row(
+                guarantorNameLast3="BROWN",
+                guarantorNameFirst3="JAMES",
+                guarantorStreetCity3="SAN ANTONIO",
+            )
+        )
+        assert debt.guarantorNameLast3 == "BROWN"
+        assert debt.guarantorNameFirst3 == "JAMES"
+        assert debt.guarantorStreetCity3 == "SAN ANTONIO"
+
+
+class TestGuarantorBlock4:
+    def test_guarantor4_fields_default_none(self):
+        debt = DebtData.model_validate(_individual_row())
+        assert debt.guarantorNameLast4 is None
+        assert debt.guarantorStreetPostalCode4 is None
+
+    def test_guarantor4_fields_set(self):
+        debt = DebtData.model_validate(
+            _individual_row(
+                guarantorNameLast4="GARCIA",
+                guarantorNameFirst4="ELENA",
+                guarantorStreetPostalCode4="78702",
+            )
+        )
+        assert debt.guarantorNameLast4 == "GARCIA"
+        assert debt.guarantorStreetPostalCode4 == "78702"
+
+
+class TestGuarantorBlock5:
+    def test_guarantor5_fields_default_none(self):
+        debt = DebtData.model_validate(_individual_row())
+        assert debt.guarantorNameLast5 is None
+        assert debt.guarantorStreetRegion5 is None
+
+    def test_guarantor5_fields_set(self):
+        debt = DebtData.model_validate(
+            _individual_row(
+                guarantorPersentTypeCd5="INDIVIDUAL",
+                guarantorNameLast5="WILLIAMS",
+                guarantorNameFirst5="ROBERT",
+                guarantorStreetCity5="EL PASO",
+                guarantorStreetStateCd5="TX",
+                guarantorStreetCountryCd5="USA",
+            )
+        )
+        assert debt.guarantorNameLast5 == "WILLIAMS"
+        assert debt.guarantorNameFirst5 == "ROBERT"
+        assert debt.guarantorStreetCity5 == "EL PASO"
+        assert debt.guarantorPersentTypeCd5 == "INDIVIDUAL"
+
+
+# ---------------------------------------------------------------------------
+# Field presence / column count sanity
+# ---------------------------------------------------------------------------
+
+
+class TestModelFieldPresence:
+    def test_all_five_guarantor_blocks_present(self):
+        """Verify all 65 guarantor fields (5 x 13) are declared on the model."""
+        fields = DebtData.model_fields
+        guarantor_fields = [f for f in fields if f.startswith("guarantor")]
+        assert len(guarantor_fields) == 65, (
+            f"Expected 65 guarantor fields, found {len(guarantor_fields)}: {guarantor_fields}"
+        )
+
+    def test_lender_camel_case_fields_present(self):
+        fields = DebtData.model_fields
+        for name in (
+            "lenderPersentTypeCd",
+            "lenderNameOrganization",
+            "lenderNameLast",
+            "lenderNameFirst",
+            "lenderNameSuffixCd",
+            "lenderNamePrefixCd",
+            "lenderNameShort",
+            "lenderStreetCity",
+            "lenderStreetStateCd",
+            "lenderStreetCountyCd",
+            "lenderStreetCountryCd",
+            "lenderStreetPostalCode",
+            "lenderStreetRegion",
+        ):
+            assert name in fields, f"Expected field {name!r} on DebtData"
+
+    def test_snake_case_ingestion_fields_preserved(self):
+        fields = DebtData.model_fields
+        assert "file_origin" in fields
+        assert "download_date" in fields
+        assert "id" in fields
+
+    def test_no_amount_fields(self):
+        """Confirm no amount/interest fields were accidentally added."""
+        fields = DebtData.model_fields
+        forbidden = {"loanAmount", "interestRate", "loanBalance", "maturityDt"}
+        present = forbidden & set(fields)
+        assert not present, f"Unexpected financial fields found: {present}"

--- a/app/tests/test_travel_validator.py
+++ b/app/tests/test_travel_validator.py
@@ -1,0 +1,191 @@
+"""Tests for TECTravelData validator and table persistence (Task 1b)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import event
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.states.texas.validators.texas_traveldata import TECTravelData
+
+# ---------------------------------------------------------------------------
+# Shared fixture data
+# ---------------------------------------------------------------------------
+
+MINIMAL_INDIVIDUAL = {
+    "recordType": "TRVL",
+    "formTypeCd": "MPAC",
+    "schedFormTypeCd": "A1",
+    "reportInfoIdent": 100001,
+    "receivedDt": "20240315",
+    "infoOnlyFlag": False,
+    "filerIdent": "00012345",
+    "filerTypeCd": "CAMPAIGN",
+    "filerName": "Smith For Governor",
+    "travelInfoId": 999,
+    "parentType": "EXPEND",
+    "parentId": 555,
+    "parentDt": "20240310",
+    "parentAmount": 1250.50,
+    "parentFullName": None,
+    "transportationTypeCd": "COMMAIR",
+    "transportationTypeDescr": "Commercial Airline",
+    "departureCity": "Austin",
+    "arrivalCity": "Dallas",
+    "departureDt": "20240310",
+    "arrivalDt": "20240310",
+    "travelPurpose": "Campaign fundraiser attendance",
+    "travellerPersentTypeCd": "INDIVIDUAL",
+    "travellerNameLast": "Smith",
+    "travellerNameFirst": "John",
+    "travellerNameSuffixCd": None,
+    "travellerNamePrefixCd": None,
+    "travellerNameShort": "J Smith",
+    "travellerNameOrganization": None,
+    "file_origin": "traveldata_2024.csv",
+    "download_date": "2024-04-01",
+}
+
+MINIMAL_ENTITY = {
+    **MINIMAL_INDIVIDUAL,
+    "travelInfoId": 1000,
+    "travellerPersentTypeCd": "ENTITY",
+    "travellerNameLast": None,
+    "travellerNameFirst": None,
+    "travellerNameShort": None,
+    "travellerNameOrganization": "Acme Consulting LLC",
+}
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestTECTravelDataValidation:
+    def test_individual_record_validates(self):
+        """A complete INDIVIDUAL travel record should pass validation."""
+        record = TECTravelData.model_validate(MINIMAL_INDIVIDUAL)
+        assert record.travelInfoId == 999
+        assert record.travellerPersentTypeCd == "INDIVIDUAL"
+        assert record.travellerNameLast == "SMITH"  # str_to_upper applied
+
+    def test_entity_record_validates(self):
+        """A complete ENTITY travel record should pass validation."""
+        record = TECTravelData.model_validate(MINIMAL_ENTITY)
+        assert record.travelInfoId == 1000
+        assert record.travellerPersentTypeCd == "ENTITY"
+        assert record.travellerNameOrganization is not None
+
+    def test_invalid_traveller_type_raises(self):
+        """travellerPersentTypeCd not in (INDIVIDUAL, ENTITY) must raise."""
+        bad_data = {**MINIMAL_INDIVIDUAL, "travellerPersentTypeCd": "PERSON"}
+        with pytest.raises((ValidationError, Exception)):
+            TECTravelData.model_validate(bad_data)
+
+    def test_individual_missing_last_name_raises(self):
+        """INDIVIDUAL without travellerNameLast must raise."""
+        bad_data = {
+            **MINIMAL_INDIVIDUAL,
+            "travellerNameLast": None,
+            "travellerNameFirst": "John",
+        }
+        with pytest.raises((ValidationError, Exception)):
+            TECTravelData.model_validate(bad_data)
+
+    def test_entity_missing_organization_raises(self):
+        """ENTITY without travellerNameOrganization must raise."""
+        bad_data = {
+            **MINIMAL_ENTITY,
+            "travellerNameOrganization": None,
+        }
+        with pytest.raises((ValidationError, Exception)):
+            TECTravelData.model_validate(bad_data)
+
+    def test_blank_strings_coerced_to_none(self):
+        """Empty strings and 'null' literals should become None."""
+        data = {
+            **MINIMAL_INDIVIDUAL,
+            "parentFullName": "",
+            "travellerNameSuffixCd": "null",
+        }
+        record = TECTravelData.model_validate(data)
+        assert record.parentFullName is None
+        assert record.travellerNameSuffixCd is None
+
+
+# ---------------------------------------------------------------------------
+# SQLModel metadata registration test
+# ---------------------------------------------------------------------------
+
+
+class TestTECTravelDataRegistration:
+    def test_table_registered_in_sqlmodel_metadata(self):
+        """table=True should register texas.tx_travel_data in SQLModel.metadata."""
+        assert TECTravelData.__table__ is not None
+        assert "texas.tx_travel_data" in SQLModel.metadata.tables
+
+    def test_primary_key_is_travel_info_id(self):
+        """travelInfoId must be the primary key column."""
+        pk_cols = [col.name for col in TECTravelData.__table__.primary_key]
+        assert "travelInfoId" in pk_cols
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip test using ATTACH DATABASE
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def texas_engine():
+    """
+    In-memory SQLite engine with a 'texas' schema attached so that
+    schema-qualified tables can be created and queried.
+    """
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def on_connect(dbapi_conn, _connection_record):
+        dbapi_conn.execute("ATTACH DATABASE ':memory:' AS texas")
+
+    # Create only the TECTravelData table in the attached schema
+    TECTravelData.__table__.create(engine, checkfirst=True)
+    return engine
+
+
+class TestTECTravelDataPersistence:
+    def test_round_trip_by_travel_info_id(self, texas_engine):
+        """Insert a validated row and retrieve it back by travelInfoId."""
+        record = TECTravelData.model_validate(MINIMAL_INDIVIDUAL)
+
+        with Session(texas_engine) as session:
+            session.add(record)
+            session.commit()
+
+        with Session(texas_engine) as session:
+            fetched = session.exec(
+                select(TECTravelData).where(TECTravelData.travelInfoId == 999)
+            ).first()
+
+        assert fetched is not None
+        assert fetched.travelInfoId == 999
+        assert fetched.travellerPersentTypeCd == "INDIVIDUAL"
+        assert fetched.parentAmount == pytest.approx(1250.50)
+        assert fetched.departureCity == "AUSTIN"
+
+    def test_entity_row_persists(self, texas_engine):
+        """An ENTITY row also round-trips correctly."""
+        record = TECTravelData.model_validate(MINIMAL_ENTITY)
+
+        with Session(texas_engine) as session:
+            session.add(record)
+            session.commit()
+
+        with Session(texas_engine) as session:
+            fetched = session.exec(
+                select(TECTravelData).where(TECTravelData.travelInfoId == 1000)
+            ).first()
+
+        assert fetched is not None
+        assert fetched.travellerNameOrganization == "ACME CONSULTING LLC"

--- a/app/tests/test_upsert.py
+++ b/app/tests/test_upsert.py
@@ -1,0 +1,214 @@
+"""Tests for app.core.upsert.bulk_upsert — SQLite in-memory only.
+
+All models defined here use schema=None so they work on plain SQLite without
+an ATTACH workaround.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+from sqlmodel import Field, Session, SQLModel, create_engine
+
+from app.core.upsert import bulk_upsert
+
+# --------------------------------------------------------------------------- #
+# Local test models (no schema= so SQLite can create them)
+# --------------------------------------------------------------------------- #
+
+
+class UpsertItem(SQLModel, table=True):
+    """Simple table: natural integer PK + one value column."""
+
+    __tablename__ = "upsert_item"
+
+    id: int = Field(primary_key=True)
+    value: str
+    created_at: Optional[str] = Field(default=None)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def engine():
+    """Fresh in-memory SQLite engine for each test."""
+    _engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    UpsertItem.__table__.create(_engine, checkfirst=True)
+    yield _engine
+    UpsertItem.__table__.drop(_engine, checkfirst=True)
+
+
+@pytest.fixture()
+def session(engine):
+    """Session bound to the test engine."""
+    with Session(engine) as s:
+        yield s
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+class TestBulkUpsertDoUpdate:
+    """DO UPDATE semantics — second write wins."""
+
+    def test_single_insert(self, session):
+        """A fresh row is inserted correctly."""
+        total = bulk_upsert(
+            session,
+            UpsertItem,
+            [{"id": 1, "value": "hello"}],
+            conflict_cols=["id"],
+        )
+        assert total == 1
+        row = session.get(UpsertItem, 1)
+        assert row is not None
+        assert row.value == "hello"
+
+    def test_upsert_overwrites_on_conflict(self, session):
+        """Inserting the same PK twice with a changed value yields ONE row
+        with the second (updated) value — DO UPDATE, not DO NOTHING."""
+        bulk_upsert(
+            session,
+            UpsertItem,
+            [{"id": 42, "value": "first"}],
+            conflict_cols=["id"],
+        )
+        bulk_upsert(
+            session,
+            UpsertItem,
+            [{"id": 42, "value": "second"}],
+            conflict_cols=["id"],
+        )
+
+        # Expire the identity-map cache so we re-read from the DB.
+        session.expire_all()
+        rows = session.exec(  # type: ignore[call-overload]
+            # Use SQLAlchemy select to avoid importing from sqlmodel.sql
+            UpsertItem.__table__.select()
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].value == "second"
+
+    def test_created_at_excluded_from_set(self, session):
+        """The created_at column is NOT included in the DO UPDATE SET clause,
+        so the original timestamp survives a conflict."""
+        bulk_upsert(
+            session,
+            UpsertItem,
+            [{"id": 7, "value": "original", "created_at": "2024-01-01"}],
+            conflict_cols=["id"],
+        )
+        bulk_upsert(
+            session,
+            UpsertItem,
+            [{"id": 7, "value": "updated", "created_at": "2099-01-01"}],
+            conflict_cols=["id"],
+        )
+
+        session.expire_all()
+        row = session.get(UpsertItem, 7)
+        assert row.value == "updated"
+        # created_at must not have been overwritten.
+        assert row.created_at == "2024-01-01"
+
+
+class TestBulkUpsertChunking:
+    """Chunk-boundary behaviour."""
+
+    def test_chunk_size_2_over_5_rows(self, session):
+        """chunk_size=2 over 5 rows should produce 5 persisted rows."""
+        rows = [{"id": i, "value": f"v{i}"} for i in range(1, 6)]
+        total = bulk_upsert(
+            session,
+            UpsertItem,
+            rows,
+            conflict_cols=["id"],
+            chunk_size=2,
+        )
+        assert total == 5
+
+        session.expire_all()
+        persisted = session.exec(UpsertItem.__table__.select()).all()
+        assert len(persisted) == 5
+
+    def test_chunk_boundary_exact_multiple(self, session):
+        """4 rows with chunk_size=2 => exactly 4 persisted rows."""
+        rows = [{"id": i, "value": f"val{i}"} for i in range(10, 14)]
+        total = bulk_upsert(
+            session,
+            UpsertItem,
+            rows,
+            conflict_cols=["id"],
+            chunk_size=2,
+        )
+        assert total == 4
+
+    def test_empty_rows_returns_zero(self, session):
+        """An empty iterable should upsert 0 rows and not raise."""
+        total = bulk_upsert(
+            session,
+            UpsertItem,
+            [],
+            conflict_cols=["id"],
+        )
+        assert total == 0
+
+
+class TestBulkUpsertExplicitUpdateCols:
+    """Explicit update_cols parameter."""
+
+    def test_explicit_update_cols_only_updates_listed_cols(self, session):
+        """When update_cols is set, only those columns are updated."""
+        bulk_upsert(
+            session,
+            UpsertItem,
+            [{"id": 99, "value": "keep", "created_at": "2020-01-01"}],
+            conflict_cols=["id"],
+            update_cols=["value"],
+        )
+        bulk_upsert(
+            session,
+            UpsertItem,
+            [{"id": 99, "value": "new_value", "created_at": "2099-01-01"}],
+            conflict_cols=["id"],
+            update_cols=["value"],
+        )
+
+        session.expire_all()
+        row = session.get(UpsertItem, 99)
+        assert row.value == "new_value"
+        # created_at was not in update_cols so must stay as-is.
+        assert row.created_at == "2020-01-01"
+
+
+class TestBulkUpsertDialect:
+    """Dialect guard."""
+
+    def test_unsupported_dialect_raises_value_error(self):
+        """Any dialect other than sqlite/postgresql raises ValueError."""
+        # Build a mock session whose get_bind() returns a fake engine with
+        # an unknown dialect.
+
+        class FakeDialect:
+            name = "mssql"
+
+        class FakeEngine:
+            dialect = FakeDialect()
+
+        class FakeSession:
+            def get_bind(self):
+                return FakeEngine()
+
+        with pytest.raises(ValueError, match="unsupported dialect"):
+            bulk_upsert(
+                FakeSession(),  # type: ignore[arg-type]
+                UpsertItem,
+                [{"id": 1, "value": "x"}],
+                conflict_cols=["id"],
+            )


### PR DESCRIPTION
Wave 1 of the **review-response-2026-06-07** remediation pack — the two ingest-blocking data-loss bugs + a real upsert-from-file primitive.

## Changes
- **DebtData** rebuilt to camelCase matching the live TEC CSV header (was snake_case → **100% of DEBT rows failed validation**, total data loss). Added all 5 guarantor blocks (65 fields). `table=True`, PK `loanInfoId`.
- **TECTravelData** → real table (`from sqlmodel import Field`, `table=True`); it was wired into the category map but could never persist.
- **`app/core/upsert.py::bulk_upsert`** — dialect-aware (sqlite + postgres) `insert().on_conflict_do_update()`, `DO UPDATE` so amended TEC records (which reuse natural ids) overwrite instead of being silently dropped. Wired into `abc_db_loader.add/add_all/add_with_limits`.

## Evidence
- 50 new unit tests (debt 32, travel 10, upsert 8); broader suite green.
- Postgres smoke on a throwaway DB with **real** CSV rows: 200/200 DEBT + 200/200 TRVL validate (was 0); re-load idempotent; amendment overwrites in place.

Deliberately **not** implemented (false-positive review findings): no DebtData amount/date/rate (those live in loans_*.csv), no contributor street lines (TEC doesn't ship them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk upsert functionality for efficient database record handling with automatic conflict resolution and configurable update behavior.

* **Chores**
  * Refactored database loader to use upsert semantics instead of simple insert operations.
  * Expanded test coverage for validators and database operations.
  * Standardized data model field naming conventions across validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->