### PR TITLE
Remediation W2: unified-layer idempotency, at-filing report cols, NULL-year campaigns

### DIFF
--- a/app/core/source_models/reports.py
+++ b/app/core/source_models/reports.py
@@ -47,6 +47,12 @@ class UnifiedReport(SQLModel, table=True):
         index=True,
     )
 
+    # Cover-sheet snapshot: committee and treasurer names as of filing time.
+    # These are denormalised from raw_data so they remain accurate even if the
+    # filer profile is updated later.
+    committee_name_at_filing: str | None = Field(default=None, max_length=200)
+    treasurer_name_at_filing: str | None = Field(default=None, max_length=200)
+
     # TEC reportInfoIdent — the report's unique identifier used for linking.
     report_ident: str = Field(max_length=20, index=True, unique=True)
 

--- a/app/core/source_models/reports_ingest.py
+++ b/app/core/source_models/reports_ingest.py
@@ -78,6 +78,17 @@ def build_report(
     if report_ident is None:
         raise ValueError("CVR1 record is missing reportInfoIdent")
 
+    # Treasurer name snapshot: branch on treasPersentTypeCd.
+    treas_type = _optional_str(raw.get("treasPersentTypeCd"))
+    if treas_type == "ENTITY":
+        treasurer_name = _optional_str(raw.get("treasNameOrganization"))
+    else:
+        # INDIVIDUAL or missing — join first + last, skipping blanks.
+        first = _optional_str(raw.get("treasNameFirst"))
+        last = _optional_str(raw.get("treasNameLast"))
+        parts = [p for p in (first, last) if p]
+        treasurer_name = " ".join(parts) if parts else None
+
     return UnifiedReport(
         state_id=state_id,
         committee_id=_optional_str(raw.get("filerIdent")),
@@ -100,6 +111,8 @@ def build_report(
         cash_on_hand=_parse_amount(raw.get("cashOnHandAmount")),
         file_origin_id=file_origin_id,
         raw_data=json.dumps(dict(raw)),
+        committee_name_at_filing=_optional_str(raw.get("filerName")),
+        treasurer_name_at_filing=treasurer_name,
     )
 
 
@@ -146,6 +159,154 @@ def link_transactions_to_reports(session: Session) -> int:
     result = session.execute(stmt)
     session.commit()
     return result.rowcount
+
+
+def backfill_report_at_filing(session: Session) -> int:
+    """Backfill ``committee_name_at_filing`` and ``treasurer_name_at_filing``
+    for existing ``unified_reports`` rows that have ``raw_data`` but whose
+    at-filing columns are NULL.
+
+    The function is dialect-aware: it uses PostgreSQL JSONB operators when
+    connected to Postgres, and ``json_extract`` for SQLite.  Two UPDATE
+    statements are issued — one for the committee name and one for the
+    treasurer name — and the total rowcount is returned.
+
+    The caller does not need to manage transactions; this function commits
+    internally (mirroring :func:`link_transactions_to_reports`).
+
+    Parameters
+    ----------
+    session:
+        Active SQLModel/SQLAlchemy session bound to either SQLite or PostgreSQL.
+
+    Returns
+    -------
+    int
+        Combined number of rows updated across both UPDATE statements.
+    """
+    dialect = session.get_bind().dialect.name
+
+    if dialect == "postgresql":
+        stmt_committee = text(
+            """
+            UPDATE unified_reports
+            SET committee_name_at_filing = NULLIF(TRIM(raw_data::jsonb ->> 'filerName'), '')
+            WHERE committee_name_at_filing IS NULL
+              AND raw_data IS NOT NULL
+            """
+        )
+        stmt_treasurer = text(
+            """
+            UPDATE unified_reports
+            SET treasurer_name_at_filing = CASE
+                WHEN TRIM(raw_data::jsonb ->> 'treasPersentTypeCd') = 'ENTITY'
+                    THEN NULLIF(TRIM(raw_data::jsonb ->> 'treasNameOrganization'), '')
+                ELSE NULLIF(
+                    TRIM(
+                        CONCAT_WS(' ',
+                            NULLIF(TRIM(raw_data::jsonb ->> 'treasNameFirst'), ''),
+                            NULLIF(TRIM(raw_data::jsonb ->> 'treasNameLast'), '')
+                        )
+                    ),
+                    ''
+                )
+            END
+            WHERE treasurer_name_at_filing IS NULL
+              AND raw_data IS NOT NULL
+            """
+        )
+    else:
+        # SQLite
+        stmt_committee = text(
+            """
+            UPDATE unified_reports
+            SET committee_name_at_filing = NULLIF(TRIM(json_extract(raw_data, '$.filerName')), '')
+            WHERE committee_name_at_filing IS NULL
+              AND raw_data IS NOT NULL
+            """
+        )
+        stmt_treasurer = text(
+            """
+            UPDATE unified_reports
+            SET treasurer_name_at_filing = CASE
+                WHEN TRIM(json_extract(raw_data, '$.treasPersentTypeCd')) = 'ENTITY'
+                    THEN NULLIF(TRIM(json_extract(raw_data, '$.treasNameOrganization')), '')
+                ELSE CASE
+                    WHEN NULLIF(TRIM(json_extract(raw_data, '$.treasNameFirst')), '') IS NOT NULL
+                         AND NULLIF(TRIM(json_extract(raw_data, '$.treasNameLast')), '') IS NOT NULL
+                        THEN TRIM(json_extract(raw_data, '$.treasNameFirst')) || ' '
+                             || TRIM(json_extract(raw_data, '$.treasNameLast'))
+                    WHEN NULLIF(TRIM(json_extract(raw_data, '$.treasNameFirst')), '') IS NOT NULL
+                        THEN TRIM(json_extract(raw_data, '$.treasNameFirst'))
+                    WHEN NULLIF(TRIM(json_extract(raw_data, '$.treasNameLast')), '') IS NOT NULL
+                        THEN TRIM(json_extract(raw_data, '$.treasNameLast'))
+                    ELSE NULL
+                END
+            END
+            WHERE treasurer_name_at_filing IS NULL
+              AND raw_data IS NOT NULL
+            """
+        )
+
+    rowcount = 0
+    rowcount += session.execute(stmt_committee).rowcount
+    rowcount += session.execute(stmt_treasurer).rowcount
+    session.commit()
+    return rowcount
+
+
+def treasurer_for_report(session: Session, report: "UnifiedReport"):
+    """Return the :class:`~app.states.texas.validators.texas_filers.TECTreasurer`
+    whose effective date range covers the report's ``filed_date``.
+
+    The lookup joins through the ``TECTreasurerLink`` association table:
+    ``unified_reports.committee_id`` is matched against
+    ``TECTreasurerLink.filer_identity_id`` (which stores the integer
+    ``filerIdent``), and ``TECTreasurerLink.treasurer_id`` links to
+    ``TECTreasurer.treasId``.
+
+    Date-range logic:
+    - ``TECTreasurer.treasEffStartDt <= report.filed_date``
+    - ``TECTreasurer.treasEffStopDt >= report.filed_date``  OR  stop date is NULL
+      (NULL stop date means the treasurer is still active / open-ended).
+
+    Parameters
+    ----------
+    session:
+        Active SQLModel/SQLAlchemy session (must have the ``texas`` schema
+        attached or be connected to a Postgres database that contains it).
+    report:
+        A :class:`~app.core.source_models.reports.UnifiedReport` instance.
+        ``committee_id`` and ``filed_date`` must be non-NULL for a match
+        to be possible.
+
+    Returns
+    -------
+    TECTreasurer | None
+        The matching treasurer record, or ``None`` if no match is found
+        (e.g. no treasurer link exists, or the report has no ``filed_date``).
+    """
+    from app.states.texas.validators.texas_filers import TECTreasurer, TECTreasurerLink
+
+    if report.committee_id is None or report.filed_date is None:
+        return None
+
+    try:
+        filer_ident = int(report.committee_id)
+    except (ValueError, TypeError):
+        return None
+
+    stmt = (
+        select(TECTreasurer)
+        .join(TECTreasurerLink, TECTreasurerLink.treasurer_id == TECTreasurer.treasId)
+        .where(TECTreasurerLink.filer_identity_id == filer_ident)
+        .where(TECTreasurer.treasEffStartDt <= report.filed_date)
+        .where(
+            (TECTreasurer.treasEffStopDt >= report.filed_date)
+            | (TECTreasurer.treasEffStopDt.is_(None))
+        )
+    )
+    return session.exec(stmt).first()
 
 
 def reconcile_report_totals(

--- a/app/core/unified_database.py
+++ b/app/core/unified_database.py
@@ -156,13 +156,21 @@ class UnifiedDatabaseManager:
         CREATE UNIQUE INDEX IF NOT EXISTS uix_txperson_txid_personid_role
         ON unified_transaction_persons (transaction_id, person_id, role);
         """,
-        # NOTE: there is intentionally NO unique index on
-        # unified_transactions (transaction_id, committee_id).  The TEC
-        # ``transaction_id`` (expendInfoId / candidateInfoId / contribInfoId …)
-        # is only unique *within* a record type, so EXPN and CAND rows reuse the
-        # same value for the same committee — a unique constraint there dropped
-        # whole files (cand, credits, assets) as false duplicates.  A plain
-        # (non-unique) index supports report-linking lookups without that.
+        # NOTE: uniqueness on unified_transactions is enforced via
+        # ``uix_transactions_state_type_sourceid`` below, which keys on
+        # (state_id, transaction_type, transaction_id).  Including
+        # ``transaction_type`` is critical: TEC ``transaction_id`` values are only
+        # unique *within* a record type, so EXPN and CAND rows reuse the same id
+        # for the same committee — a two-column (transaction_id, committee_id)
+        # index dropped whole files (cand, credits, assets) as false duplicates.
+        # Adding transaction_type disambiguates those record types, making the
+        # unique constraint safe and correct.  The plain ix_transactions_source_id
+        # index is retained to support fast report-linking lookups.
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uix_transactions_state_type_sourceid
+        ON unified_transactions (state_id, transaction_type, transaction_id)
+        WHERE transaction_id IS NOT NULL;
+        """,
         """
         CREATE INDEX IF NOT EXISTS ix_transactions_source_id
         ON unified_transactions (transaction_id, committee_id)

--- a/app/core/unified_state_loader.py
+++ b/app/core/unified_state_loader.py
@@ -396,28 +396,29 @@ class UnifiedStateLoader:
         with self._db_manager.get_session() as session:
             _committees, _persons, state_id, state_code = self._load_batch_indexes(session)
 
-            # Guard: skip entire file if already loaded to prevent duplicate rows on
-            # re-runs. FileOrigin uses a SHA-256 key of (state_id, filename) so the
-            # same file always produces the same id.
+            # Provenance: create-or-fetch the FileOrigin for this file so that
+            # file_origin_id can be set on every transaction row.  Idempotency now
+            # rests on the natural-key upsert in _persist_transaction_from_record,
+            # not on skipping the entire file.
+            file_origin_id: str | None = None
             if file_path and state_id is not None:
                 from app.core.models import FileOrigin
                 origin_key = FileOrigin.build_key(state_id, file_name)
                 existing_origin = session.get(FileOrigin, origin_key)
                 if existing_origin is not None:
-                    # Check if there are already transactions from this file
-                    from sqlmodel import select as _select
-                    already_loaded = session.exec(
-                        _select(UnifiedTransaction.id)
-                        .where(UnifiedTransaction.file_origin_id == origin_key)
-                        .limit(1)
-                    ).first()
-                    if already_loaded is not None:
-                        logger.info(
-                            f"Skipping {file_name!r} — already loaded "
-                            f"(origin_id={origin_key[:12]}…)"
-                        )
-                        stats.skipped = len(records)
-                        return stats
+                    logger.info(
+                        f"File {file_name!r} already loaded "
+                        f"(origin_id={origin_key[:12]}…); "
+                        "relying on natural-key upsert for idempotency"
+                    )
+                    file_origin_id = origin_key
+                else:
+                    new_origin = FileOrigin(
+                        id=origin_key, state_id=state_id, filename=file_name
+                    )
+                    session.add(new_origin)
+                    session.flush()
+                    file_origin_id = origin_key
             if state_id is None:
                 msg = (
                     f"State '{self.state}' is not present in the states table; "
@@ -437,6 +438,7 @@ class UnifiedStateLoader:
                             session,
                             state_id=state_id,
                             state_code=state_code,
+                            file_origin_id=file_origin_id,
                         )
                         if transaction is None:
                             stats.skipped += 1
@@ -468,8 +470,17 @@ class UnifiedStateLoader:
         *,
         state_id: int | None,
         state_code: str | None,
+        file_origin_id: str | None = None,
     ) -> UnifiedTransaction | None:
-        """Build and persist one transaction using the batch session."""
+        """Build and persist one transaction using the batch session.
+
+        When the freshly-built transaction has a non-NULL transaction_id the
+        method first checks for an existing row with the same
+        (state_id, transaction_type, transaction_id) natural key.  If found,
+        mutable fields are updated on the EXISTING row and that row is returned
+        — no duplicate INSERT.  This is the select-then-mutate pattern used
+        throughout this function for committee/person dedup.
+        """
         transaction = unified_sql_processor.process_record(
             record,
             self.state,
@@ -477,6 +488,36 @@ class UnifiedStateLoader:
             state_code=state_code,
             session=session,
         )
+
+        # Set file_origin provenance before the natural-key check so that any
+        # upsert update also refreshes the file_origin_id.
+        if file_origin_id is not None:
+            transaction.file_origin_id = file_origin_id
+
+        # ------------------------------------------------------------------
+        # Natural-key upsert: if an existing transaction matches
+        # (state_id, transaction_type, transaction_id) update its mutable
+        # fields and return the persisted row to avoid a duplicate INSERT.
+        # ------------------------------------------------------------------
+        if transaction.transaction_id is not None and state_id is not None:
+            existing_tx: UnifiedTransaction | None = session.exec(
+                select(UnifiedTransaction).where(
+                    UnifiedTransaction.state_id == state_id,
+                    UnifiedTransaction.transaction_type == transaction.transaction_type,
+                    UnifiedTransaction.transaction_id == transaction.transaction_id,
+                )
+            ).first()
+            if existing_tx is not None:
+                # Update mutable fields from the freshly-built transaction.
+                existing_tx.amount = transaction.amount
+                existing_tx.transaction_date = transaction.transaction_date
+                existing_tx.description = transaction.description
+                existing_tx.report_ident = transaction.report_ident
+                if file_origin_id is not None:
+                    existing_tx.file_origin_id = file_origin_id
+                existing_tx.updated_at = transaction.updated_at
+                session.flush()
+                return existing_tx
 
         if transaction.committee:
             filer_id = transaction.committee.filer_id

--- a/app/resolve/publish/campaigns.py
+++ b/app/resolve/publish/campaigns.py
@@ -6,6 +6,13 @@ cycle)`` — not something that needs probabilistic resolution.  This maps every
 (committee → canonical committee entity; candidate person → canonical entity),
 deduping by the identity tuple.  Run after the entity pass so the crosswalk is
 populated.
+
+**Sentinel value for missing election year:** When ``election_year`` is NULL
+(officeholder committees, multi-cycle PACs, and other filers with no election
+year), ``election_cycle`` is stored as ``0``.  The identity tuple is therefore
+``(committee_entity, office, 0)`` for such rows.  ``election_cycle == 0`` means
+"no election cycle / officeholder" — it is *not* a real cycle.  The builder is
+delete-and-rebuild each run, so the sentinel cannot drift into an invalid state.
 """
 
 from __future__ import annotations
@@ -73,7 +80,7 @@ def build_canonical_campaigns(
             SELECT id, primary_committee_id, candidate_person_id, election_year,
                    office_sought, name
             FROM unified_campaigns
-            WHERE primary_committee_id IS NOT NULL AND election_year IS NOT NULL
+            WHERE primary_committee_id IS NOT NULL
             """
         )
     ).fetchall()
@@ -89,7 +96,10 @@ def build_canonical_campaigns(
         if committee_entity_id is None:
             continue
         office = _office_normalized(office_sought)
-        key = (committee_entity_id, office, int(election_year))
+        # election_cycle == 0 means "no election cycle / officeholder"; NULL
+        # election_year maps to sentinel 0 so the non-null column stays valid.
+        cycle = int(election_year) if election_year is not None else 0
+        key = (committee_entity_id, office, cycle)
         candidate_entity_id = (
             person_xw.get(str(candidate_person_id))
             if candidate_person_id is not None
@@ -107,7 +117,7 @@ def build_canonical_campaigns(
         by_identity[key] = CanonicalCampaign(
             committee_entity_id=committee_entity_id,
             office_normalized=office,
-            election_cycle=int(election_year),
+            election_cycle=cycle,  # 0 when election_year is NULL (officeholder sentinel)
             candidate_entity_id=candidate_entity_id,
             canonical_name=name,
             state_code=state_code,

--- a/scripts/dedup_unified_transactions.py
+++ b/scripts/dedup_unified_transactions.py
@@ -1,0 +1,169 @@
+"""One-off dedup of legacy duplicate unified_transactions rows.
+
+Background
+----------
+Before the Wave-2 natural-key upsert (review-response-2026-06-07), the
+insert-only + FileOrigin-guard load path produced duplicate
+``(state_id, transaction_type, transaction_id)`` groups whenever the same TEC
+record arrived under a differently-named file. The new unique partial index
+``uix_transactions_state_type_sourceid`` cannot be created on a database that
+still holds those duplicates. Fresh loads are already clean (the upsert prevents
+new duplicates); this script removes the *existing* legacy duplicates so the
+index can be applied to a pre-existing database.
+
+What it does (single transaction)
+---------------------------------
+1. Stage the non-surviving duplicate parent ids into a temp table: for each
+   ``(state_id, transaction_type, transaction_id)`` group (transaction_id NOT
+   NULL) it KEEPS the lowest ``id`` and marks the rest for removal.
+2. Purge the children of those doomed parents in every FK-referencing detail
+   table (all reference ``unified_transactions.id`` via their own
+   ``transaction_id`` column, all ``ON DELETE NO ACTION`` — children first).
+3. Purge the doomed parent rows.
+4. Optionally create the unique index.
+
+Safety
+------
+- DRY-RUN BY DEFAULT: prints the counts it *would* purge and rolls back.
+  Pass ``--apply`` to commit.
+- All-or-nothing: everything runs in one transaction.
+- ``--create-index`` additionally creates the unique partial index after the
+  cleanup (only meaningful with ``--apply``).
+
+Usage
+-----
+    uv run python scripts/dedup_unified_transactions.py \
+        --db-url postgresql+psycopg2://USER@localhost:5432/DBNAME            # dry-run
+    uv run python scripts/dedup_unified_transactions.py --db-url ... --apply --create-index
+
+All SQL is static (no identifier interpolation).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from sqlalchemy import create_engine, text
+
+# (table, static purge statement), ordered deepest-FK-first. loan_guarantors is a
+# GRANDCHILD: it FK-references unified_loans.id (loan_id) and unified_debts.id
+# (debt_id), so it must be purged before those detail tables. Everything else
+# FK-references unified_transactions.id via its own transaction_id column. All FKs
+# are ON DELETE NO ACTION, so descendants must be removed before ancestors.
+_CHILD_PURGES: tuple[tuple[str, str], ...] = (
+    # grandchildren (reference the loan/debt detail tables) — purge first
+    ("loan_guarantors", "DELETE FROM loan_guarantors WHERE loan_id IN (SELECT id FROM unified_loans WHERE transaction_id IN (SELECT id FROM _doomed_txn))"),
+    ("loan_guarantors", "DELETE FROM loan_guarantors WHERE debt_id IN (SELECT id FROM unified_debts WHERE transaction_id IN (SELECT id FROM _doomed_txn))"),
+    # children (reference unified_transactions.id via transaction_id)
+    ("unified_transaction_persons", "DELETE FROM unified_transaction_persons  WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_transaction_versions", "DELETE FROM unified_transaction_versions WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_contributions", "DELETE FROM unified_contributions        WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_expenditures", "DELETE FROM unified_expenditures         WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_loans", "DELETE FROM unified_loans                WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_debts", "DELETE FROM unified_debts                WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_credits", "DELETE FROM unified_credits              WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_travel", "DELETE FROM unified_travel               WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_assets", "DELETE FROM unified_assets               WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+    ("unified_pledges", "DELETE FROM unified_pledges              WHERE transaction_id IN (SELECT id FROM _doomed_txn)"),
+)
+
+_CREATE_DOOMED = text("CREATE TEMP TABLE _doomed_txn (id INTEGER PRIMARY KEY) ON COMMIT DROP")
+
+_POPULATE_DOOMED = text(
+    """
+    INSERT INTO _doomed_txn (id)
+    SELECT id FROM (
+        SELECT id,
+               row_number() OVER (
+                   PARTITION BY state_id, transaction_type, transaction_id
+                   ORDER BY id
+               ) AS rn
+        FROM unified_transactions
+        WHERE transaction_id IS NOT NULL
+    ) ranked
+    WHERE ranked.rn > 1
+    """
+)
+
+_COUNT_DOOMED = text("SELECT count(*) FROM _doomed_txn")
+_COUNT_GROUPS = text(
+    """
+    SELECT count(*) FROM (
+        SELECT 1 FROM unified_transactions
+        WHERE transaction_id IS NOT NULL
+        GROUP BY state_id, transaction_type, transaction_id
+        HAVING count(*) > 1
+    ) g
+    """
+)
+_PURGE_PARENTS = text("DELETE FROM unified_transactions WHERE id IN (SELECT id FROM _doomed_txn)")
+_CREATE_INDEX = text(
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS uix_transactions_state_type_sourceid
+    ON unified_transactions (state_id, transaction_type, transaction_id)
+    WHERE transaction_id IS NOT NULL
+    """
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Dedup legacy unified_transactions duplicates.")
+    parser.add_argument("--db-url", required=True, help="SQLAlchemy database URL")
+    parser.add_argument(
+        "--apply", action="store_true", help="Commit the cleanup (default: dry-run + rollback)"
+    )
+    parser.add_argument(
+        "--create-index",
+        action="store_true",
+        help="Also create uix_transactions_state_type_sourceid after cleanup",
+    )
+    args = parser.parse_args(argv)
+
+    # PostgreSQL-only: the staging temp table uses `ON COMMIT DROP`, which SQLite
+    # does not support. Fail with a clear message rather than an opaque syntax error.
+    if "postgresql" not in args.db_url and "postgres" not in args.db_url:
+        sys.exit(
+            "This dedup script supports PostgreSQL only "
+            "(uses ON COMMIT DROP temp tables). Got: " + args.db_url.split("://", 1)[0]
+        )
+
+    engine = create_engine(args.db_url)
+    conn = engine.connect()
+    trans = conn.begin()  # single transaction, explicit commit/rollback below
+    try:
+        conn.execute(_CREATE_DOOMED)
+        conn.execute(_POPULATE_DOOMED)
+        groups = conn.execute(_COUNT_GROUPS).scalar_one()
+        doomed = conn.execute(_COUNT_DOOMED).scalar_one()
+        print(f"duplicate groups: {groups:,}")
+        print(f"non-surviving rows to purge (keeping lowest id per group): {doomed:,}")
+
+        for table, stmt in _CHILD_PURGES:
+            res = conn.execute(text(stmt))
+            if res.rowcount:
+                print(f"  purged {res.rowcount:,} child rows in {table}")
+
+        parent_res = conn.execute(_PURGE_PARENTS)
+        print(f"purged {parent_res.rowcount:,} parent unified_transactions rows")
+
+        if args.create_index:
+            conn.execute(_CREATE_INDEX)
+            print("created uix_transactions_state_type_sourceid")
+
+        if args.apply:
+            trans.commit()
+            print("\nAPPLIED — committed.")
+        else:
+            trans.rollback()
+            print("\nDRY RUN — rolled back. Re-run with --apply to commit.")
+    except Exception:
+        trans.rollback()
+        raise
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/core/test_reports_at_filing.py
+++ b/tests/core/test_reports_at_filing.py
@@ -1,0 +1,332 @@
+"""Tests for Task 2a — at-filing columns, backfill, and treasurer helper.
+
+Covers:
+- build_report() populates committee_name_at_filing and treasurer_name_at_filing
+  for both INDIVIDUAL and ENTITY treasurer types.
+- backfill_report_at_filing() correctly updates NULL at-filing columns from
+  stored raw_data JSON on SQLite.
+- treasurer_for_report() returns None cleanly when no matching treasurer exists
+  (avoids the heavyweight TECTreasurer address validator in unit tests).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlmodel import Session, create_engine
+
+import app.core.models  # noqa: F401 — ensure unified tables are registered
+from app.core.source_models.reports import UnifiedReport
+from app.core.source_models.reports_ingest import (
+    backfill_report_at_filing,
+    build_report,
+    treasurer_for_report,
+)
+from tests.resolve.conftest import (
+    StubFileOrigin,
+    StubState,
+    StubUnifiedCommittee,
+    create_resolve_tables,
+)
+
+# ---------------------------------------------------------------------------
+# Shared raw-dict fixtures
+# ---------------------------------------------------------------------------
+
+BASE_CVR1: dict = {
+    "recordType": "CVR1",
+    "formTypeCd": "GPAC",
+    "reportInfoIdent": "11111111111",
+    "filerIdent": "00012345",
+    "filerTypeCd": "GPAC",
+    "filerName": "Acme Political Action Committee",
+    "filedDt": "20240315",
+    "periodStartDt": "20240101",
+    "periodEndDt": "20240331",
+    "totalContribAmount": "1000.00",
+    "unitemizedContribAmount": "0.00",
+    "totalExpendAmount": "500.00",
+    "unitemizedExpendAmount": "0.00",
+    "loanBalanceAmount": "0.00",
+    "contribsMaintainedAmount": "500.00",
+    "cashOnHandAmount": "500.00",
+}
+
+INDIVIDUAL_CVR1: dict = {
+    **BASE_CVR1,
+    "treasPersentTypeCd": "INDIVIDUAL",
+    "treasNameFirst": "Jane",
+    "treasNameLast": "Doe",
+    "treasNameOrganization": "",
+}
+
+ENTITY_CVR1: dict = {
+    **BASE_CVR1,
+    "reportInfoIdent": "22222222222",
+    "treasPersentTypeCd": "ENTITY",
+    "treasNameFirst": "",
+    "treasNameLast": "",
+    "treasNameOrganization": "Finance Corp LLC",
+}
+
+MISSING_TREAS_CVR1: dict = {
+    **BASE_CVR1,
+    "reportInfoIdent": "33333333333",
+    # No treas* keys at all
+}
+
+
+# ---------------------------------------------------------------------------
+# build_report() at-filing column tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReportAtFilingColumns:
+    """Verify build_report() populates at-filing snapshot columns."""
+
+    def test_committee_name_populated_from_filer_name(self) -> None:
+        report = build_report(BASE_CVR1, state_id=43)
+        assert report.committee_name_at_filing == "Acme Political Action Committee"
+
+    def test_filer_name_missing_yields_none(self) -> None:
+        raw = dict(BASE_CVR1, reportInfoIdent="44444444444")
+        raw.pop("filerName", None)
+        report = build_report(raw, state_id=43)
+        assert report.committee_name_at_filing is None
+
+    def test_filer_name_blank_yields_none(self) -> None:
+        raw = dict(BASE_CVR1, reportInfoIdent="55555555555", filerName="   ")
+        report = build_report(raw, state_id=43)
+        assert report.committee_name_at_filing is None
+
+    def test_individual_treasurer_joined_first_last(self) -> None:
+        report = build_report(INDIVIDUAL_CVR1, state_id=43)
+        assert report.treasurer_name_at_filing == "Jane Doe"
+
+    def test_entity_treasurer_uses_organization(self) -> None:
+        report = build_report(ENTITY_CVR1, state_id=43)
+        assert report.treasurer_name_at_filing == "Finance Corp LLC"
+
+    def test_individual_only_last_name(self) -> None:
+        raw = dict(
+            INDIVIDUAL_CVR1,
+            reportInfoIdent="66666666666",
+            treasNameFirst="",
+            treasNameLast="Smith",
+        )
+        report = build_report(raw, state_id=43)
+        assert report.treasurer_name_at_filing == "Smith"
+
+    def test_individual_only_first_name(self) -> None:
+        raw = dict(
+            INDIVIDUAL_CVR1,
+            reportInfoIdent="77777777777",
+            treasNameFirst="Alice",
+            treasNameLast="",
+        )
+        report = build_report(raw, state_id=43)
+        assert report.treasurer_name_at_filing == "Alice"
+
+    def test_no_treasurer_fields_yields_none(self) -> None:
+        report = build_report(MISSING_TREAS_CVR1, state_id=43)
+        assert report.treasurer_name_at_filing is None
+
+    def test_unknown_treas_type_treated_as_individual(self) -> None:
+        """Unrecognised treasPersentTypeCd falls through to the INDIVIDUAL branch."""
+        raw = dict(
+            INDIVIDUAL_CVR1,
+            reportInfoIdent="88888888888",
+            treasPersentTypeCd="UNKNOWN",
+            treasNameFirst="Bob",
+            treasNameLast="Jones",
+        )
+        report = build_report(raw, state_id=43)
+        assert report.treasurer_name_at_filing == "Bob Jones"
+
+
+# ---------------------------------------------------------------------------
+# backfill_report_at_filing() — SQLite in-memory engine
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="backfill_session")
+def backfill_session_fixture():
+    """Fresh SQLite in-memory engine with only schema-less unified tables."""
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    create_resolve_tables(
+        engine,
+        stub_tables=[
+            StubState.__table__,
+            StubFileOrigin.__table__,
+            StubUnifiedCommittee.__table__,
+        ],
+        app_tables=[UnifiedReport.__table__],
+    )
+    with Session(engine) as session:
+        session.add(StubState(id=43, code="TX"))
+        session.add(StubUnifiedCommittee(filer_id="00012345", name="Acme PAC"))
+        session.commit()
+        yield session
+
+
+def _insert_report_with_null_at_filing(
+    session: Session,
+    *,
+    report_ident: str,
+    raw: dict,
+) -> UnifiedReport:
+    """Insert a UnifiedReport with at-filing columns forced to NULL."""
+    report = build_report(raw, state_id=43)
+    report.report_ident = report_ident
+    # Force NULL to simulate a row that predates the backfill.
+    report.committee_name_at_filing = None
+    report.treasurer_name_at_filing = None
+    session.add(report)
+    session.commit()
+    session.refresh(report)
+    return report
+
+
+class TestBackfillReportAtFiling:
+    """backfill_report_at_filing() populates NULL columns from raw_data JSON."""
+
+    def test_backfill_populates_committee_name(
+        self, backfill_session: Session
+    ) -> None:
+        raw = dict(BASE_CVR1, filerName="Test Committee Name")
+        report = _insert_report_with_null_at_filing(
+            backfill_session, report_ident="91111111111", raw=raw
+        )
+        assert report.committee_name_at_filing is None  # guard
+
+        count = backfill_report_at_filing(backfill_session)
+        assert count >= 1
+
+        backfill_session.refresh(report)
+        assert report.committee_name_at_filing == "Test Committee Name"
+
+    def test_backfill_populates_individual_treasurer(
+        self, backfill_session: Session
+    ) -> None:
+        raw = dict(
+            INDIVIDUAL_CVR1,
+            reportInfoIdent="92222222222",
+            treasNameFirst="Carlos",
+            treasNameLast="Rivera",
+        )
+        report = _insert_report_with_null_at_filing(
+            backfill_session, report_ident="92222222222", raw=raw
+        )
+        assert report.treasurer_name_at_filing is None  # guard
+
+        backfill_report_at_filing(backfill_session)
+
+        backfill_session.refresh(report)
+        assert report.treasurer_name_at_filing == "Carlos Rivera"
+
+    def test_backfill_populates_entity_treasurer(
+        self, backfill_session: Session
+    ) -> None:
+        raw = dict(
+            ENTITY_CVR1,
+            reportInfoIdent="93333333333",
+            treasNameOrganization="River Finance LLC",
+        )
+        report = _insert_report_with_null_at_filing(
+            backfill_session, report_ident="93333333333", raw=raw
+        )
+        backfill_report_at_filing(backfill_session)
+        backfill_session.refresh(report)
+        assert report.treasurer_name_at_filing == "River Finance LLC"
+
+    def test_backfill_skips_already_populated(
+        self, backfill_session: Session
+    ) -> None:
+        """A row with committee_name_at_filing already set is not overwritten."""
+        raw = dict(BASE_CVR1, reportInfoIdent="94444444444", filerName="Already Set")
+        report = build_report(raw, state_id=43)
+        report.report_ident = "94444444444"
+        report.committee_name_at_filing = "Pre-existing Value"
+        backfill_session.add(report)
+        backfill_session.commit()
+        backfill_session.refresh(report)
+
+        backfill_report_at_filing(backfill_session)
+        backfill_session.refresh(report)
+        assert report.committee_name_at_filing == "Pre-existing Value"
+
+    def test_backfill_skips_null_raw_data(self, backfill_session: Session) -> None:
+        """Rows with NULL raw_data are not touched by the backfill."""
+        report = UnifiedReport(
+            state_id=43,
+            committee_id="00012345",
+            report_ident="95555555555",
+            raw_data=None,
+            committee_name_at_filing=None,
+            treasurer_name_at_filing=None,
+        )
+        backfill_session.add(report)
+        backfill_session.commit()
+        backfill_session.refresh(report)
+
+        backfill_report_at_filing(backfill_session)
+        backfill_session.refresh(report)
+        assert report.committee_name_at_filing is None
+
+    def test_backfill_returns_rowcount(self, backfill_session: Session) -> None:
+        """Return value is an int (the combined rowcount of both UPDATEs)."""
+        raw = dict(BASE_CVR1, reportInfoIdent="96666666666")
+        _insert_report_with_null_at_filing(
+            backfill_session, report_ident="96666666666", raw=raw
+        )
+        count = backfill_report_at_filing(backfill_session)
+        assert isinstance(count, int)
+        assert count >= 0
+
+
+# ---------------------------------------------------------------------------
+# treasurer_for_report() — light test (no-match path)
+#
+# TECTreasurer rows require a valid address via the Pydantic model-validator,
+# making them heavyweight to construct in a pure unit test.  We verify the
+# helper returns None cleanly when no treasurer is linked, which exercises the
+# query path without needing a fully populated texas schema.
+# ---------------------------------------------------------------------------
+
+
+class TestTreasurerForReport:
+    """treasurer_for_report() returns None when no treasurer match exists."""
+
+    def test_returns_none_when_no_committee_id(self, backfill_session: Session) -> None:
+        report = UnifiedReport(
+            state_id=43,
+            report_ident="97777777777",
+            committee_id=None,
+            filed_date=date(2024, 3, 15),
+        )
+        result = treasurer_for_report(backfill_session, report)
+        assert result is None
+
+    def test_returns_none_when_no_filed_date(self, backfill_session: Session) -> None:
+        report = UnifiedReport(
+            state_id=43,
+            report_ident="97777777778",
+            committee_id="00012345",
+            filed_date=None,
+        )
+        result = treasurer_for_report(backfill_session, report)
+        assert result is None
+
+    def test_returns_none_when_non_integer_committee_id(
+        self, backfill_session: Session
+    ) -> None:
+        """committee_id that cannot be cast to int returns None gracefully."""
+        report = UnifiedReport(
+            state_id=43,
+            report_ident="97777777779",
+            committee_id="not-an-int",
+            filed_date=date(2024, 3, 15),
+        )
+        result = treasurer_for_report(backfill_session, report)
+        assert result is None

--- a/tests/core/test_unified_state_loader_integration.py
+++ b/tests/core/test_unified_state_loader_integration.py
@@ -9,7 +9,7 @@ from sqlmodel import Session, SQLModel, create_engine, select
 
 import app.core.models  # noqa: F401 — register unified tables
 from app.core.enums import TransactionType
-from app.core.models import State, UnifiedTransaction
+from app.core.models import FileOrigin, State, UnifiedTransaction
 from app.core.unified_database import UnifiedDatabaseManager, get_db_manager, reset_db_manager_cache
 from app.core.unified_state_loader import UnifiedStateLoader
 
@@ -87,4 +87,106 @@ def test_process_records_batch_raises_when_state_missing(
         loader.process_records_batch([_contribution_record()])
 
     reset_db_manager_cache()
+
+
+def _contribution_record_with_id(tx_id: str, amount: str = "500.00") -> dict:
+    """A contribution record with an explicit contributionInfoId (transaction_id)."""
+    return {
+        "record_type": "RCPT",
+        "filerIdent": "99001",
+        "contributionInfoId": tx_id,
+        "contributionAmount": amount,
+        "contributionDt": "2024-03-01",
+    }
+
+
+def test_reload_same_file_yields_same_row_count(
+    loader: UnifiedStateLoader,
+    loader_db_manager: UnifiedDatabaseManager,
+    sqlite_engine,
+) -> None:
+    """Re-loading the same records (same file name + same transaction_id) must NOT
+    duplicate rows — idempotency is now enforced by the natural-key upsert, not
+    by early-returning when the file is already loaded."""
+    records = [
+        _contribution_record_with_id("TX-001"),
+        _contribution_record_with_id("TX-002"),
+    ]
+    file_path = Path("contrib.parquet")
+
+    # First load
+    stats1 = loader.process_records_batch(records, file_path=file_path)
+    assert stats1.success == 2
+
+    with Session(sqlite_engine) as session:
+        rows_after_first = session.exec(select(UnifiedTransaction)).all()
+    assert len(rows_after_first) == 2
+
+    # Second load of the exact same records — must stay at 2 rows, not 4
+    stats2 = loader.process_records_batch(records, file_path=file_path)
+    # Upserted rows come back as success (the existing row is mutated and returned)
+    assert stats2.success == 2
+
+    with Session(sqlite_engine) as session:
+        rows_after_second = session.exec(select(UnifiedTransaction)).all()
+    assert len(rows_after_second) == 2, (
+        "Re-loading the same file must not create duplicate rows"
+    )
+
+
+def test_natural_key_upsert_overwrites_mutable_fields(
+    loader: UnifiedStateLoader,
+    loader_db_manager: UnifiedDatabaseManager,
+    sqlite_engine,
+) -> None:
+    """When a record with the same natural key is re-loaded with an amended amount,
+    the existing row's amount must be updated to the new value."""
+    file_path = Path("contrib.parquet")
+
+    # Initial load
+    records_v1 = [_contribution_record_with_id("TX-100", amount="100.00")]
+    stats1 = loader.process_records_batch(records_v1, file_path=file_path)
+    assert stats1.success == 1
+
+    with Session(sqlite_engine) as session:
+        rows = session.exec(select(UnifiedTransaction)).all()
+    assert len(rows) == 1
+    assert float(rows[0].amount) == pytest.approx(100.0)
+
+    # Re-load with an amended amount
+    records_v2 = [_contribution_record_with_id("TX-100", amount="250.00")]
+    stats2 = loader.process_records_batch(records_v2, file_path=file_path)
+    assert stats2.success == 1
+
+    with Session(sqlite_engine) as session:
+        rows = session.exec(select(UnifiedTransaction)).all()
+    assert len(rows) == 1, "Upsert must update in-place, not add a duplicate row"
+    assert float(rows[0].amount) == pytest.approx(250.0), (
+        "Amended amount must overwrite the original"
+    )
+
+
+def test_reload_creates_file_origin_provenance(
+    loader: UnifiedStateLoader,
+    loader_db_manager: UnifiedDatabaseManager,
+    sqlite_engine,
+) -> None:
+    """process_records_batch must create a FileOrigin record on first load and
+    reuse the existing one on second load (no duplicate FileOrigin rows)."""
+    records = [_contribution_record_with_id("TX-200")]
+    file_path = Path("contrib_prov.parquet")
+
+    loader.process_records_batch(records, file_path=file_path)
+
+    with Session(sqlite_engine) as session:
+        origins = session.exec(select(FileOrigin)).all()
+    assert len(origins) == 1
+    assert origins[0].filename == file_path.name
+
+    # Second load must not create a second FileOrigin row
+    loader.process_records_batch(records, file_path=file_path)
+
+    with Session(sqlite_engine) as session:
+        origins_after = session.exec(select(FileOrigin)).all()
+    assert len(origins_after) == 1, "FileOrigin must not be duplicated on re-load"
 

--- a/tests/resolve/test_canonical_campaigns.py
+++ b/tests/resolve/test_canonical_campaigns.py
@@ -1,0 +1,230 @@
+"""Tests for canonical-campaign builder — Task 2c.
+
+Covers the NULL election_year sentinel (election_cycle == 0) for officeholder
+and multi-cycle committees that carry no election year.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlmodel import Session
+
+from app.resolve.publish.campaigns import build_canonical_campaigns
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def session() -> Session:
+    """Fresh in-memory SQLite session with all tables needed by the builder."""
+    engine = create_engine("sqlite:///:memory:", echo=False)
+    with Session(engine) as db:
+        _create_tables(db)
+        yield db
+    engine.dispose()
+
+
+def _create_tables(session: Session) -> None:
+    """Create minimal table DDL for the campaign builder (raw SQL, no FK deps)."""
+    session.execute(
+        text(
+            """
+            CREATE TABLE unified_campaigns (
+                id INTEGER PRIMARY KEY,
+                primary_committee_id TEXT,
+                candidate_person_id TEXT,
+                election_year INTEGER,
+                office_sought TEXT,
+                name TEXT
+            )
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            CREATE TABLE entity_crosswalk (
+                id INTEGER PRIMARY KEY,
+                source_type TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                canonical_entity_id INTEGER NOT NULL,
+                run_id INTEGER
+            )
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            CREATE TABLE canonical_entity (
+                id INTEGER PRIMARY KEY,
+                canonical_name TEXT NOT NULL
+            )
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            CREATE TABLE canonical_campaign (
+                id INTEGER PRIMARY KEY,
+                uuid TEXT NOT NULL UNIQUE,
+                committee_entity_id INTEGER NOT NULL,
+                office_normalized TEXT,
+                election_cycle INTEGER NOT NULL,
+                candidate_entity_id INTEGER,
+                canonical_name TEXT,
+                state_code TEXT NOT NULL,
+                district TEXT,
+                last_run_id INTEGER,
+                created_at TEXT,
+                updated_at TEXT
+            )
+            """
+        )
+    )
+    session.commit()
+
+
+def _seed_officeholder(session: Session) -> None:
+    """Insert a canonical entity, crosswalk entry, and one unified_campaign
+    row with election_year = NULL (the officeholder case)."""
+    session.execute(
+        text("INSERT INTO canonical_entity (id, canonical_name) VALUES (1, 'Officeholder PAC')")
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO entity_crosswalk
+                (source_type, source_id, canonical_entity_id, run_id)
+            VALUES ('unified_committee', 'COM-001', 1, 1)
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO unified_campaigns
+                (id, primary_committee_id, candidate_person_id, election_year, office_sought, name)
+            VALUES (10, 'COM-001', NULL, NULL, 'governor', 'Officeholder PAC Campaign')
+            """
+        )
+    )
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNullElectionYearSentinel:
+    def test_officeholder_committee_produces_one_row(self, session: Session) -> None:
+        """A committee with NULL election_year must produce exactly one canonical_campaign."""
+        _seed_officeholder(session)
+
+        count = build_canonical_campaigns(session, state_code="TX")
+
+        assert count == 1
+
+    def test_election_cycle_is_zero_sentinel(self, session: Session) -> None:
+        """election_cycle must be 0 when election_year is NULL."""
+        _seed_officeholder(session)
+        build_canonical_campaigns(session, state_code="TX")
+
+        row = session.execute(
+            text("SELECT election_cycle FROM canonical_campaign WHERE state_code = 'TX'")
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 0, f"Expected election_cycle=0 (sentinel), got {row[0]}"
+
+    def test_idempotent_two_consecutive_runs_no_duplicate(self, session: Session) -> None:
+        """Two consecutive build_canonical_campaigns calls must yield exactly one
+        canonical_campaign row (builder is delete-and-rebuild; no duplicate)."""
+        _seed_officeholder(session)
+
+        first_count = build_canonical_campaigns(session, state_code="TX")
+        second_count = build_canonical_campaigns(session, state_code="TX")
+
+        assert first_count == 1
+        assert second_count == 1
+
+        # Confirm exactly one row in the table after both runs.
+        total = session.execute(
+            text("SELECT COUNT(*) FROM canonical_campaign WHERE state_code = 'TX'")
+        ).scalar_one()
+        assert total == 1, f"Expected 1 row after two runs, found {total}"
+
+    def test_regular_campaign_unaffected(self, session: Session) -> None:
+        """A campaign with a non-NULL election_year is still picked up correctly."""
+        session.execute(
+            text("INSERT INTO canonical_entity (id, canonical_name) VALUES (2, 'Regular PAC')")
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO entity_crosswalk
+                    (source_type, source_id, canonical_entity_id, run_id)
+                VALUES ('unified_committee', 'COM-002', 2, 1)
+                """
+            )
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO unified_campaigns
+                    (id, primary_committee_id, candidate_person_id, election_year, office_sought, name)
+                VALUES (20, 'COM-002', NULL, 2024, 'senate', 'Regular PAC 2024')
+                """
+            )
+        )
+        session.commit()
+
+        count = build_canonical_campaigns(session, state_code="TX")
+        assert count == 1
+
+        row = session.execute(
+            text("SELECT election_cycle FROM canonical_campaign WHERE state_code = 'TX'")
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 2024
+
+    def test_mixed_null_and_non_null_election_years(self, session: Session) -> None:
+        """Both a NULL and a non-NULL election_year committee produce separate rows."""
+        _seed_officeholder(session)
+        session.execute(
+            text("INSERT INTO canonical_entity (id, canonical_name) VALUES (2, 'Regular PAC')")
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO entity_crosswalk
+                    (source_type, source_id, canonical_entity_id, run_id)
+                VALUES ('unified_committee', 'COM-002', 2, 1)
+                """
+            )
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO unified_campaigns
+                    (id, primary_committee_id, candidate_person_id, election_year, office_sought, name)
+                VALUES (20, 'COM-002', NULL, 2026, 'governor', 'Regular PAC 2026')
+                """
+            )
+        )
+        session.commit()
+
+        count = build_canonical_campaigns(session, state_code="TX")
+        assert count == 2
+
+        cycles = sorted(
+            row[0]
+            for row in session.execute(
+                text("SELECT election_cycle FROM canonical_campaign WHERE state_code = 'TX'")
+            ).fetchall()
+        )
+        assert cycles == [0, 2026]


### PR DESCRIPTION
Wave 2 of the **review-response-2026-06-07** remediation pack.

## Changes
- **UnifiedReport** `committee_name_at_filing` / `treasurer_name_at_filing`, populated in `build_report`; CLI-callable set-based backfill from existing `raw_data` JSON (no re-ingest); `treasurer_for_report` date-range join helper (no treasurer FK — the join is the relational model).
- **unified_transactions** natural-key idempotency: unique partial index `(state_id, transaction_type, transaction_id) WHERE transaction_id IS NOT NULL` (keying on transaction_type disambiguates EXPN/CAND id-reuse); `_persist_transaction_from_record` select-then-mutates on the natural key; FileOrigin whole-file guard demoted to logging.
- **Canonical campaigns** with NULL election year: dropped the `election_year IS NOT NULL` filter; sentinel cycle `0`.
- **`scripts/dedup_unified_transactions.py`** — one-off, transactional, dry-run-by-default cleanup of pre-fix legacy duplicate transaction groups (purges FK descendants incl. the `loan_guarantors` grandchild first), required before the new unique index can apply to a pre-existing DB.

## Evidence
- New tests: at-filing (18), canonical-campaign NULL-year (5), loader idempotency (3); full suite green.
- Dedup script dry-run-validated on both dev DBs (campaign_finance 888 groups, spike 17,707 + index created in-txn before rollback).

> Note: existing dev/spike DBs hold legacy duplicate groups that must be deduped (via the script) before the unique index can be created on them. Fresh loads are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)