### PR TITLE
Remediation W3: employer signal, selective org cross-role blocking, employer survivorship

### DIFF
--- a/app/resolve/blocking.py
+++ b/app/resolve/blocking.py
@@ -106,6 +106,18 @@ def default_blocking_rules() -> list[BlockingRule]:
             name="org_normalized_zip3",
             fields=("normalized_org", "zip3"),
         ),
+        # Cross-role org blocking: connects the same normalized org across
+        # different addresses (ZIPs) within a state — the D-org case the zip3 rule
+        # misses. Blocks on EXACT normalized_org + state (NOT a first-word
+        # phonetic: (org_name_phonetic, state) measured ~9,200x pair explosion on
+        # real data; (normalized_org, state) is ~1.2x). Fuzzy name variants are
+        # handled by the org JaroWinkler comparison at scoring time.
+        # LOCK-STEP: also in organization.PREDICTION_BLOCKING_RULES and
+        # blocking_sql._RULE_BLOCK_KEY_SQL — update all three together.
+        BlockingRule(
+            name="org_normalized_state",
+            fields=("normalized_org", "state"),
+        ),
     ]
 
 

--- a/app/resolve/blocking_sql.py
+++ b/app/resolve/blocking_sql.py
@@ -60,6 +60,24 @@ _RULE_BLOCK_KEY_SQL: dict[str, str] = {
         "THEN lower(trim(ri.normalized_org)) || '|' || "
         "lower(substr(trim(ri.zip5), 1, 3)) END"
     ),
+    # Cross-role org blocking: connects the same normalized org across different
+    # addresses (ZIPs) within a state — the D-org case the zip3 rule misses. The
+    # entity-type guard keeps person records out of org candidate pairs. Blocks on
+    # EXACT normalized_org + state, NOT a first-word phonetic: measured on real
+    # spike data, (org_name_phonetic, state) exploded pairs ~9,200x (34.1M vs
+    # 3.7k) — org_name_phonetic is only the first token's phonetic and state is
+    # TX-dominated; (normalized_org, state) is ~1.2x (4.4k).
+    # LOCK-STEP: also in blocking.default_blocking_rules() and
+    # organization.PREDICTION_BLOCKING_RULES — update all three together.
+    "org_normalized_state": (
+        "CASE WHEN ri.entity_type IN ('organization', 'committee') "
+        "AND ri.normalized_org IS NOT NULL "
+        "AND trim(ri.normalized_org) <> '' "
+        "AND ri.state IS NOT NULL "
+        "AND trim(ri.state) <> '' "
+        "THEN lower(trim(ri.normalized_org)) || '|' || "
+        "lower(trim(ri.state)) END"
+    ),
 }
 
 _DROP_TEMP_SQL = "DROP TABLE IF EXISTS blocking_keyed_stage"

--- a/app/resolve/models/canonical.py
+++ b/app/resolve/models/canonical.py
@@ -216,10 +216,17 @@ class CanonicalEntity(SQLModel, table=True):
     last_seen_date: Optional[date] = Field(default=None)
     source_record_count: int = Field(default=0)
 
+    # Most-recent employer across cluster rows (non-null/non-blank rows only).
+    # Determined by last_activity_date (fallback: created_at) of the winning row.
+    # Rebuilt each run — no migration needed.
+    employer: Optional[str] = Field(default=None, max_length=500)
+
     # JSON string mapping field name → {source_type, source_id} of the record
     # whose value was selected during survivorship.  Added in Phase 2 (task-2d);
     # the canonical tables are rebuilt each run so the column simply appears on
     # the next freshly-created staging table without a migration.
+    # Also carries "employer_history": list of {value, first_seen, last_seen}
+    # per distinct employer value, ordered by first_seen then value.
     provenance_json: Optional[str] = Field(default=None)
 
     last_run_id: Optional[int] = Field(default=None, index=True)

--- a/app/resolve/splink_config/organization.py
+++ b/app/resolve/splink_config/organization.py
@@ -33,10 +33,25 @@ COMPARISONS = [
 # Blocks on normalized org name + ZIP3 for EM training.
 TRAINING_BLOCKING_RULE = block_on("normalized_org", "zip3")
 
-# Prediction blocking mirrors Phase-1 org_normalized_zip3 rule.  The SQL blocking
-# now scopes each rule by entity_type (see blocking_sql._RULE_BLOCK_KEY_SQL), so
-# organization candidate pairs come only from this rule and Splink's bulk predict
-# reproduces them — no per-pair fallback.
+# Prediction blocking mirrors Phase-1 org blocking rules.  The SQL blocking now
+# scopes each rule by entity_type (see blocking_sql._RULE_BLOCK_KEY_SQL), so
+# organization candidate pairs come only from these rules and Splink's bulk
+# predict reproduces them — no per-pair fallback.
+#
+# LOCK-STEP WARNING: every rule here must have a matching entry in BOTH
+# blocking.default_blocking_rules() and blocking_sql._RULE_BLOCK_KEY_SQL.
+# Adding or removing a rule in one place without updating the other two will
+# cause the SQL blocker to generate pairs that Splink cannot reproduce in bulk
+# predict, forcing a slow per-pair fallback.
+# The second rule connects the SAME normalized org across different addresses
+# (different ZIPs) within a state — the D-org cross-role/cross-address case the
+# zip3 rule misses. It blocks on EXACT normalized_org (not a first-word phonetic):
+# measured on real spike data, (org_name_phonetic, state) exploded candidate
+# pairs ~9,200x (34.1M vs 3.7k) because org_name_phonetic is only the phonetic of
+# the first name token and state is TX-dominated; (normalized_org, state) is ~1.2x
+# (4.4k). Fuzzy name variants are still caught by the JaroWinkler comparison at
+# scoring time.
 PREDICTION_BLOCKING_RULES = [
     block_on("normalized_org", "zip3"),
+    block_on("normalized_org", "state"),
 ]

--- a/app/resolve/splink_config/person.py
+++ b/app/resolve/splink_config/person.py
@@ -26,6 +26,13 @@ COMPARISONS = [
     cl.ExactMatch("line_1").configure(term_frequency_adjustments=True),
     cl.ExactMatch("city"),
     cl.ExactMatch("zip5"),
+    # Employer — used as a soft comparison signal only, never a blocking key.
+    # Employers change over time; blocking on employer would split the same
+    # person across filing years.  This field is null-heavy: only
+    # contribution-sourced persons carry it; Splink handles nulls natively via
+    # its null-level gamma bucket.  EM training must re-estimate m/u weights
+    # after this comparison is added.
+    cl.JaroWinklerAtThresholds("employer", [0.88]),
 ]
 
 # ---------------------------------------------------------------------------

--- a/app/resolve/stages/score.py
+++ b/app/resolve/stages/score.py
@@ -120,6 +120,11 @@ def _row_to_dict(row: ResolutionInput) -> dict[str, Any]:
         "last_name": row.last_name or "",
         "last_name_phonetic": row.last_name_phonetic or "",
         "normalized_org": row.normalized_org or "",
+        # Employer feeds the person comparison (splink_config.person). Kept as
+        # None (not "") when absent so Splink treats it as NULL — otherwise two
+        # employer-less people would JaroWinkler-match "" == "" and get a
+        # spurious match boost. Harmless extra column for non-person configs.
+        "employer": row.employer,
         "line_1": row.line_1 or "",
         "city": row.city or "",
         "state": row.state or "",
@@ -769,6 +774,13 @@ def _score_entity_type_streaming(
     if not rec_dicts:
         return 0
     df = pd.DataFrame(rec_dicts)
+    # Force employer to a string dtype so DuckDB types it VARCHAR even when the
+    # whole batch is NULL (every org row, or a person subset with no employers).
+    # An all-None object column infers as INTEGER, and Splink's person comparison
+    # SQL fails to *bind* jaro_winkler_similarity(employer_l, employer_r) — even
+    # though the NULL-level short-circuits at runtime. "string" keeps NA as NULL.
+    if "employer" in df.columns:
+        df["employer"] = df["employer"].astype("string")
     rec_by_uid = {d["unique_id"]: d for d in rec_dicts}
     del rec_dicts
 

--- a/app/resolve/stages/survivorship.py
+++ b/app/resolve/stages/survivorship.py
@@ -26,6 +26,7 @@ import json
 import uuid as _uuid_mod
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Any
 
 from sqlalchemy import delete
@@ -181,6 +182,63 @@ def _pick_best_name_row(rows: list[ResolutionInput]) -> ResolutionInput:
     return max(rows, key=lambda r: (_name_completeness(r), r.created_at))
 
 
+def _row_activity_date(row: ResolutionInput) -> date:
+    """Return the best single date for a row: last_activity_date, first_activity_date, or created_at.date()."""
+    if row.last_activity_date is not None:
+        return row.last_activity_date
+    if row.first_activity_date is not None:
+        return row.first_activity_date
+    return row.created_at.date()
+
+
+def _pick_employer(rows: list[ResolutionInput]) -> str | None:
+    """Return the employer from the most-recent row (by activity/created date) that has a non-null, non-blank employer.
+
+    Returns None when no row in the cluster carries an employer.
+    """
+    employer_rows = [r for r in rows if r.employer and r.employer.strip()]
+    if not employer_rows:
+        return None
+    # Pick the most-recent by last_activity_date → first_activity_date → created_at.
+    best = max(employer_rows, key=_row_activity_date)
+    return best.employer
+
+
+def _build_employer_history(rows: list[ResolutionInput]) -> list[dict[str, str]]:
+    """Aggregate per-cluster employer history as a list of dicts.
+
+    Returns one entry per distinct employer value (after stripping whitespace),
+    each with:
+        value      — the employer string
+        first_seen — ISO date string of the earliest date any row with that employer has
+        last_seen  — ISO date string of the latest date any row with that employer has
+
+    Dates use last_activity_date → first_activity_date → created_at fallback.
+    The list is ordered by (first_seen, value) for determinism.
+    Returns an empty list when no row carries an employer.
+    """
+    employer_rows = [r for r in rows if r.employer and r.employer.strip()]
+    if not employer_rows:
+        return []
+
+    by_employer: dict[str, list[date]] = defaultdict(list)
+    for row in employer_rows:
+        by_employer[row.employer.strip()].append(_row_activity_date(row))
+
+    history: list[dict[str, str]] = []
+    for value, dates in by_employer.items():
+        history.append(
+            {
+                "value": value,
+                "first_seen": min(dates).isoformat(),
+                "last_seen": max(dates).isoformat(),
+            }
+        )
+
+    history.sort(key=lambda e: (e["first_seen"], e["value"]))
+    return history
+
+
 def _pick_best_address_row(rows: list[ResolutionInput]) -> ResolutionInput | None:
     """Return the most recent fully-parsed address row, or None if none exist."""
     parsed = [r for r in rows if r.parse_status == "parsed"]
@@ -297,6 +355,12 @@ def build_golden_record(
             "source_id": best_address_row.source_id,
         }
 
+    # Employer survivorship — scalar (most-recent) + history in provenance.
+    employer = _pick_employer(cluster_rows)
+    employer_history = _build_employer_history(cluster_rows)
+    if employer_history:
+        provenance["employer_history"] = employer_history
+
     return CanonicalEntity(
         entity_type=entity_type,
         canonical_name=canonical_name,
@@ -305,6 +369,7 @@ def build_golden_record(
         first_seen_date=first_seen,
         last_seen_date=last_seen,
         source_record_count=len(cluster.members),
+        employer=employer,
         provenance_json=json.dumps(provenance),
     )
 

--- a/app/resolve/standardize/stage1.py
+++ b/app/resolve/standardize/stage1.py
@@ -170,6 +170,7 @@ def _collect_source_rows(session: Session, state_id: int) -> list[dict[str, Any]
             UnifiedPerson.last_name,
             UnifiedPerson.suffix,
             UnifiedPerson.organization,
+            UnifiedPerson.employer,
             UnifiedAddress.street_1,
             UnifiedAddress.street_2,
             UnifiedAddress.city,
@@ -232,6 +233,7 @@ def _collect_source_rows(session: Session, state_id: int) -> list[dict[str, Any]
                 "raw_address": _compose_raw_address(
                     row.street_1, row.street_2, row.city, row.state, row.zip_code
                 ),
+                "employer": row.employer,
                 "first_activity_date": p_first,
                 "last_activity_date": p_last,
             }
@@ -341,8 +343,13 @@ def _compute_features(rows: list[dict[str, Any]], run_id: int) -> list[Resolutio
     linked_ids = [
         (r.get("linked_person_id"), r.get("linked_committee_id")) for r in rows
     ]
+    # Employer is only present on person rows; keep it out of the Polars frame so
+    # that mixed-type schema inference (str | None vs absent key) does not break.
+    # Normalize using the same org-name helper as normalized_org.
+    raw_employers = [r.get("employer") for r in rows]
     _frame_skip = (
         "first_activity_date", "last_activity_date", "linked_person_id", "linked_committee_id",
+        "employer",
     )
     frame_rows = [
         {k: v for k, v in r.items() if k not in _frame_skip}
@@ -379,6 +386,8 @@ def _compute_features(rows: list[dict[str, Any]], run_id: int) -> list[Resolutio
         name_values = _name_fields(row["std_name"])
         address_values = _address_fields(row["std_address"])
         normalized_org = row["normalized_org"] or ""
+        raw_employer = raw_employers[idx]
+        normalized_employer = normalize_org_name(raw_employer) if raw_employer else None
         staged.append(
             ResolutionInput(
                 run_id=run_id,
@@ -389,6 +398,7 @@ def _compute_features(rows: list[dict[str, Any]], run_id: int) -> list[Resolutio
                 org_name_phonetic=phonetic_code(normalized_org.split(" ")[0])
                 if normalized_org
                 else "",
+                employer=normalized_employer or None,
                 raw_name=row["raw_name"],
                 raw_address=row["raw_address"],
                 first_activity_date=first_activity_date,

--- a/app/resolve/standardize/staging.py
+++ b/app/resolve/standardize/staging.py
@@ -60,6 +60,7 @@ class ResolutionInput(SQLModel, table=True):
     parse_status: str = Field(default="unparsed", sa_column=Column(String(20), nullable=False))
 
     normalized_org: str | None = Field(default=None, sa_column=Column(String(500)))
+    employer: str | None = Field(default=None, sa_column=Column(String(500)))
     first_name_phonetic: str | None = Field(default=None, sa_column=Column(String(50)))
     last_name_phonetic: str | None = Field(default=None, sa_column=Column(String(50)))
     org_name_phonetic: str | None = Field(default=None, sa_column=Column(String(50)))

--- a/tests/resolve/test_employer_signal.py
+++ b/tests/resolve/test_employer_signal.py
@@ -1,0 +1,197 @@
+"""Tests for employer as a Splink comparison signal (Task 3a).
+
+Verifies:
+(a) person.py COMPARISONS contains an employer comparison and neither
+    blocking-rule constant references "employer".
+(b) _compute_features normalizes employer from source person rows and
+    leaves it None when absent.
+"""
+
+from __future__ import annotations
+
+from sqlmodel import SQLModel, create_engine
+
+import app.resolve.models  # noqa: F401 — register UnifiedReport before ORM use
+from app.resolve.splink_config.person import (
+    COMPARISONS,
+    PREDICTION_BLOCKING_RULES,
+    TRAINING_BLOCKING_RULE,
+)
+from app.resolve.standardize.stage1 import _compute_features
+from app.resolve.standardize.staging import ResolutionInput
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _blocking_rule_col_names(rule) -> set[str]:
+    """Recursively collect all column output_column_name values from a blocking rule.
+
+    block_on() returns an And object with a .blocking_rules list of
+    ExactMatchRule objects, each with a .col_expression attribute.
+    """
+    names: set[str] = []
+    sub_rules = getattr(rule, "blocking_rules", None)
+    if sub_rules:
+        for sub in sub_rules:
+            names.extend(_blocking_rule_col_names(sub))
+    else:
+        ce = getattr(rule, "col_expression", None)
+        if ce is not None:
+            names.append(ce.output_column_name)
+    return set(names)
+
+
+# ---------------------------------------------------------------------------
+# (a) Config-level assertions
+# ---------------------------------------------------------------------------
+
+
+def test_comparisons_contains_employer():
+    """COMPARISONS must include exactly one employer comparison."""
+    employer_comps = [
+        c for c in COMPARISONS
+        if c.create_output_column_name() == "employer"
+    ]
+    assert len(employer_comps) == 1, (
+        f"Expected 1 employer comparison in COMPARISONS, found {len(employer_comps)}"
+    )
+
+
+def test_training_blocking_rule_does_not_reference_employer():
+    """TRAINING_BLOCKING_RULE must not reference the employer column."""
+    cols = _blocking_rule_col_names(TRAINING_BLOCKING_RULE)
+    assert "employer" not in cols, (
+        f"TRAINING_BLOCKING_RULE unexpectedly references employer; columns found: {cols}"
+    )
+
+
+def test_prediction_blocking_rules_do_not_reference_employer():
+    """PREDICTION_BLOCKING_RULES must not reference the employer column."""
+    for rule in PREDICTION_BLOCKING_RULES:
+        cols = _blocking_rule_col_names(rule)
+        assert "employer" not in cols, (
+            f"PREDICTION_BLOCKING_RULES entry unexpectedly references employer; columns: {cols}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) Feature-computation assertions
+# ---------------------------------------------------------------------------
+
+
+def _make_engine():
+    """Return a fresh in-memory SQLite engine with only the schema-less tables."""
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    tables = [t for t in SQLModel.metadata.tables.values() if t.schema is None]
+    SQLModel.metadata.create_all(engine, tables=tables)
+    return engine
+
+
+def test_compute_features_normalizes_employer():
+    """A person source dict with an employer produces a normalized employer on ResolutionInput."""
+    rows = [
+        {
+            "source_type": "unified_person",
+            "source_id": "1",
+            "entity_type": "person",
+            "raw_name": "Jane Doe",
+            "raw_address": "100 Main St, Austin, TX 78701",
+            "employer": "Acme Corp., LLC",
+        }
+    ]
+    results = _compute_features(rows, run_id=1)
+    assert len(results) == 1
+    ri = results[0]
+    # normalize_org_name lowercases, strips legal suffixes, strips punctuation
+    assert ri.employer is not None
+    assert "acme" in ri.employer
+    # punctuation and legal suffix stripped
+    assert "." not in ri.employer
+    assert "llc" not in ri.employer
+
+
+def test_compute_features_employer_none_when_absent():
+    """A person source dict without an employer key yields employer=None."""
+    rows = [
+        {
+            "source_type": "unified_person",
+            "source_id": "2",
+            "entity_type": "person",
+            "raw_name": "Bob Smith",
+            "raw_address": "200 Oak Ave, Dallas, TX 75201",
+            # No 'employer' key — simulates committee or entity rows
+        }
+    ]
+    results = _compute_features(rows, run_id=1)
+    assert len(results) == 1
+    assert results[0].employer is None
+
+
+def test_compute_features_employer_none_when_blank():
+    """A person source dict with empty-string employer yields employer=None."""
+    rows = [
+        {
+            "source_type": "unified_person",
+            "source_id": "3",
+            "entity_type": "person",
+            "raw_name": "Alice Jones",
+            "raw_address": "300 Elm St, Houston, TX 77001",
+            "employer": "",
+        }
+    ]
+    results = _compute_features(rows, run_id=1)
+    assert len(results) == 1
+    assert results[0].employer is None
+
+
+def test_compute_features_mixed_employer_rows():
+    """Mixed rows (person with employer, person without) produce correct per-row employer values."""
+    rows = [
+        {
+            "source_type": "unified_person",
+            "source_id": "10",
+            "entity_type": "person",
+            "raw_name": "Carol White",
+            "raw_address": "10 Maple Dr, San Antonio, TX 78201",
+            "employer": "Texas Oil & Gas Inc",
+        },
+        {
+            "source_type": "unified_person",
+            "source_id": "11",
+            "entity_type": "person",
+            "raw_name": "Dave Brown",
+            "raw_address": "20 Pine St, Austin, TX 78702",
+        },
+        {
+            "source_type": "unified_committee",
+            "source_id": "CMT-99",
+            "entity_type": "committee",
+            "raw_name": "Friends of Carol",
+            "raw_address": "",
+        },
+    ]
+    results = _compute_features(rows, run_id=2)
+    assert len(results) == 3
+
+    carol = results[0]
+    dave = results[1]
+    committee = results[2]
+
+    # Carol has an employer — normalized (lowercased, & expanded, suffix stripped)
+    assert carol.employer is not None
+    assert "texas oil" in carol.employer
+
+    # Dave has no employer key
+    assert dave.employer is None
+
+    # Committee has no employer
+    assert committee.employer is None
+
+
+def test_resolution_input_has_employer_column():
+    """ResolutionInput.__table__ must declare an 'employer' column of length 500."""
+    col = ResolutionInput.__table__.c.get("employer")
+    assert col is not None, "employer column missing from ResolutionInput"
+    assert col.type.length == 500

--- a/tests/resolve/test_employer_survivorship.py
+++ b/tests/resolve/test_employer_survivorship.py
@@ -1,0 +1,352 @@
+"""Task 3c — Employer survivorship + history.
+
+Tests for:
+- CanonicalEntity.employer scalar: most-recent row (by activity/created date) with
+  a non-null, non-blank employer.
+- provenance_json["employer_history"]: list of {value, first_seen, last_seen} per
+  distinct employer value, ordered by (first_seen, value).
+- Cluster with no employer → employer is None and no employer_history key.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+
+from app.resolve.stages.survivorship import (
+    Cluster,
+    build_golden_record,
+)
+from app.resolve.standardize.staging import ResolutionInput
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dt(d: str) -> datetime:
+    """Parse an ISO date string into a UTC datetime (midnight)."""
+    return datetime.fromisoformat(d).replace(tzinfo=timezone.utc)
+
+
+def _make_row(
+    source_id: str,
+    *,
+    employer: str | None = None,
+    last_activity_date: date | None = None,
+    first_activity_date: date | None = None,
+    created_at: datetime | None = None,
+    first_name: str = "John",
+    last_name: str = "Doe",
+    source_type: str = "unified_person",
+    entity_type: str = "person",
+) -> ResolutionInput:
+    """Create an in-memory (unpersisted) ResolutionInput with just the fields under test."""
+    return ResolutionInput(
+        run_id=1,
+        source_type=source_type,
+        source_id=source_id,
+        entity_type=entity_type,
+        first_name=first_name,
+        last_name=last_name,
+        raw_name=f"{first_name} {last_name}",
+        is_organization=False,
+        parse_status="unparsed",
+        employer=employer,
+        first_activity_date=first_activity_date,
+        last_activity_date=last_activity_date,
+        created_at=created_at or _dt("2024-01-01"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: scalar employer selection
+# ---------------------------------------------------------------------------
+
+
+class TestEmployerScalar:
+    def test_most_recent_by_last_activity_date_wins(self):
+        """When rows have distinct last_activity_dates, the most recent wins."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row(
+                "1",
+                employer="Acme Corp",
+                last_activity_date=date(2020, 1, 1),
+                created_at=_dt("2020-01-01"),
+            ),
+            _make_row(
+                "2",
+                employer="Globex",
+                last_activity_date=date(2023, 6, 15),
+                created_at=_dt("2020-01-01"),
+            ),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer == "Globex"
+
+    def test_fallback_to_created_at_when_no_activity_dates(self):
+        """When no activity dates exist, most-recent created_at determines employer."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row("1", employer="OldCo", created_at=_dt("2019-03-01")),
+            _make_row("2", employer="NewCo", created_at=_dt("2024-07-04")),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer == "NewCo"
+
+    def test_null_employer_rows_excluded_from_selection(self):
+        """Rows with null employer do not compete for the scalar employer."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            # Newer row but no employer
+            _make_row("1", employer=None, last_activity_date=date(2025, 1, 1)),
+            # Older row with employer
+            _make_row("2", employer="OnlyCo", last_activity_date=date(2018, 1, 1)),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer == "OnlyCo"
+
+    def test_blank_employer_rows_excluded_from_selection(self):
+        """Rows with blank/whitespace-only employer are treated as absent."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row("1", employer="   ", last_activity_date=date(2025, 1, 1)),
+            _make_row("2", employer="RealCo", last_activity_date=date(2018, 1, 1)),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer == "RealCo"
+
+    def test_no_employer_in_cluster_returns_none(self):
+        """A cluster where no row has a non-null employer → entity.employer is None."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row("1", employer=None),
+            _make_row("2", employer=""),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer is None
+
+    def test_singleton_cluster_with_employer(self):
+        """A single-member cluster with an employer propagates it correctly."""
+        cluster = Cluster(members=[("unified_person", "1")])
+        rows = [_make_row("1", employer="SoloCo", last_activity_date=date(2022, 5, 1))]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer == "SoloCo"
+
+    def test_first_activity_date_used_when_no_last_activity(self):
+        """When last_activity_date is absent, first_activity_date is used as tiebreaker."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row("1", employer="EarlyCo", first_activity_date=date(2019, 1, 1)),
+            _make_row("2", employer="LateCo", first_activity_date=date(2022, 1, 1)),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer == "LateCo"
+
+
+# ---------------------------------------------------------------------------
+# Tests: employer_history in provenance_json
+# ---------------------------------------------------------------------------
+
+
+class TestEmployerHistory:
+    def test_two_distinct_employers_produce_two_history_entries(self):
+        """Two distinct employer values across the cluster → two employer_history entries."""
+        cluster = Cluster(
+            members=[("unified_person", "1"), ("unified_person", "2"), ("unified_person", "3")]
+        )
+        rows = [
+            _make_row(
+                "1",
+                employer="Acme Corp",
+                last_activity_date=date(2018, 1, 1),
+                created_at=_dt("2018-01-01"),
+            ),
+            _make_row(
+                "2",
+                employer="Acme Corp",
+                last_activity_date=date(2019, 6, 30),
+                created_at=_dt("2019-06-30"),
+            ),
+            _make_row(
+                "3",
+                employer="Globex",
+                last_activity_date=date(2021, 3, 15),
+                created_at=_dt("2021-03-15"),
+            ),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        prov = json.loads(entity.provenance_json)
+        assert "employer_history" in prov
+        history = prov["employer_history"]
+        assert len(history) == 2
+
+    def test_employer_history_values_are_correct(self):
+        """employer_history entries have correct value, first_seen, last_seen."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row(
+                "1",
+                employer="Acme Corp",
+                last_activity_date=date(2018, 3, 1),
+                created_at=_dt("2018-03-01"),
+            ),
+            _make_row(
+                "2",
+                employer="Globex",
+                last_activity_date=date(2022, 9, 10),
+                created_at=_dt("2022-09-10"),
+            ),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        prov = json.loads(entity.provenance_json)
+        history = prov["employer_history"]
+        history_by_value = {e["value"]: e for e in history}
+
+        assert "Acme Corp" in history_by_value
+        assert history_by_value["Acme Corp"]["first_seen"] == "2018-03-01"
+        assert history_by_value["Acme Corp"]["last_seen"] == "2018-03-01"
+
+        assert "Globex" in history_by_value
+        assert history_by_value["Globex"]["first_seen"] == "2022-09-10"
+        assert history_by_value["Globex"]["last_seen"] == "2022-09-10"
+
+    def test_employer_history_spans_correct_dates_for_repeated_employer(self):
+        """When multiple rows share the same employer, first_seen=min and last_seen=max."""
+        cluster = Cluster(
+            members=[("unified_person", "1"), ("unified_person", "2"), ("unified_person", "3")]
+        )
+        rows = [
+            _make_row(
+                "1",
+                employer="Acme Corp",
+                last_activity_date=date(2015, 1, 1),
+            ),
+            _make_row(
+                "2",
+                employer="Acme Corp",
+                last_activity_date=date(2020, 12, 31),
+            ),
+            _make_row(
+                "3",
+                employer="Acme Corp",
+                last_activity_date=date(2018, 6, 15),
+            ),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        prov = json.loads(entity.provenance_json)
+        history = prov["employer_history"]
+        assert len(history) == 1
+        entry = history[0]
+        assert entry["value"] == "Acme Corp"
+        assert entry["first_seen"] == "2015-01-01"
+        assert entry["last_seen"] == "2020-12-31"
+
+    def test_employer_history_ordered_by_first_seen_then_value(self):
+        """employer_history is sorted by (first_seen, value) for determinism."""
+        cluster = Cluster(
+            members=[
+                ("unified_person", "1"),
+                ("unified_person", "2"),
+                ("unified_person", "3"),
+            ]
+        )
+        rows = [
+            _make_row(
+                "1",
+                employer="Zebra Inc",
+                last_activity_date=date(2015, 1, 1),
+            ),
+            _make_row(
+                "2",
+                employer="Apple LLC",
+                last_activity_date=date(2015, 1, 1),
+            ),
+            _make_row(
+                "3",
+                employer="Globex",
+                last_activity_date=date(2022, 1, 1),
+            ),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        prov = json.loads(entity.provenance_json)
+        history = prov["employer_history"]
+        values_in_order = [e["value"] for e in history]
+        # "Apple LLC" and "Zebra Inc" both have first_seen 2015-01-01;
+        # alphabetically Apple comes before Zebra.
+        assert values_in_order == ["Apple LLC", "Zebra Inc", "Globex"]
+
+    def test_no_employer_produces_no_employer_history_key(self):
+        """A cluster with no employer rows → provenance_json has no employer_history key."""
+        cluster = Cluster(members=[("unified_person", "1")])
+        rows = [_make_row("1", employer=None)]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer is None
+        prov = json.loads(entity.provenance_json)
+        assert "employer_history" not in prov
+
+    def test_employer_history_dates_fallback_to_created_at(self):
+        """When activity dates are absent, history first/last_seen derive from created_at."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row("1", employer="WorkCo", created_at=_dt("2017-04-10")),
+            _make_row("2", employer="WorkCo", created_at=_dt("2023-11-05")),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        prov = json.loads(entity.provenance_json)
+        history = prov["employer_history"]
+        assert len(history) == 1
+        assert history[0]["first_seen"] == "2017-04-10"
+        assert history[0]["last_seen"] == "2023-11-05"
+
+    def test_employer_scalar_matches_most_recent_history_entry(self):
+        """entity.employer matches the employer of the row with the latest activity date."""
+        cluster = Cluster(members=[("unified_person", "1"), ("unified_person", "2")])
+        rows = [
+            _make_row(
+                "1",
+                employer="OldCo",
+                last_activity_date=date(2015, 6, 1),
+            ),
+            _make_row(
+                "2",
+                employer="NewCo",
+                last_activity_date=date(2023, 3, 20),
+            ),
+        ]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        assert entity.employer == "NewCo"
+        prov = json.loads(entity.provenance_json)
+        history = prov["employer_history"]
+        history_by_value = {e["value"]: e for e in history}
+        # NewCo is the most recent (last_seen 2023)
+        assert "NewCo" in history_by_value
+
+    def test_existing_provenance_keys_preserved_with_employer(self):
+        """Adding employer_history must not clobber canonical_name or other provenance keys."""
+        cluster = Cluster(members=[("unified_person", "1")])
+        rows = [_make_row("1", employer="MyCo", last_activity_date=date(2022, 1, 1))]
+        entity = build_golden_record(cluster, rows, "TX")
+
+        prov = json.loads(entity.provenance_json)
+        # Pre-existing keys must still be present
+        assert "canonical_name" in prov
+        assert "first_seen_date" in prov
+        assert "last_seen_date" in prov
+        # And new key
+        assert "employer_history" in prov

--- a/tests/resolve/test_org_cross_role_blocking.py
+++ b/tests/resolve/test_org_cross_role_blocking.py
@@ -1,0 +1,146 @@
+"""Tests for Task 3b — org cross-role blocking on (normalized_org, state).
+
+The original spec proposed (org_name_phonetic, state); measured on real spike
+data that exploded candidate pairs ~9,200x (org_name_phonetic is only the
+first-token phonetic and state is TX-dominated), so per the pack's >5x guardrail
+the rule was corrected to EXACT (normalized_org, state) (~1.2x). Fuzzy name
+variants are still caught by the org JaroWinkler comparison at scoring time.
+
+Verifies the rule is registered consistently across all three lock-step
+locations:
+  1. organization.PREDICTION_BLOCKING_RULES (Splink bulk-predict)
+  2. blocking.default_blocking_rules()       (Python + SQL stage-2 blocking)
+  3. blocking_sql._RULE_BLOCK_KEY_SQL        (static SQL key expressions)
+Also checks the functional key-derivation behaviour of the BlockingRule itself.
+"""
+
+from __future__ import annotations
+
+from app.resolve.blocking import BlockingRule, default_blocking_rules
+from app.resolve.blocking_sql import _RULE_BLOCK_KEY_SQL
+from app.resolve.splink_config import organization as org_config
+from app.resolve.standardize.staging import ResolutionInput
+
+_RULE_NAME = "org_normalized_state"
+_RULE_FIELDS = ("normalized_org", "state")
+
+# ---------------------------------------------------------------------------
+# (a) PREDICTION_BLOCKING_RULES has 2 rules and one blocks on the new pair
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_blocking_rules_count():
+    """organization.PREDICTION_BLOCKING_RULES must now contain exactly 2 rules."""
+    assert len(org_config.PREDICTION_BLOCKING_RULES) == 2
+
+
+def _splink_rule_column_names(rule) -> list[str]:
+    """Extract column names from a Splink block_on() (And) object."""
+    sub_rules = getattr(rule, "blocking_rules", [])
+    return [getattr(br.col_expression, "raw_sql_expression", "") for br in sub_rules]
+
+
+def test_prediction_blocking_rules_includes_normalized_org_state():
+    """One rule must block on normalized_org + state (and NOT org_name_phonetic)."""
+    found = any(
+        "normalized_org" in _splink_rule_column_names(rule)
+        and "state" in _splink_rule_column_names(rule)
+        for rule in org_config.PREDICTION_BLOCKING_RULES
+    )
+    assert found, (
+        "No rule references both normalized_org and state. Rules present: "
+        + repr(org_config.PREDICTION_BLOCKING_RULES)
+    )
+    # The coarse first-token phonetic rule must NOT be present (it exploded pairs).
+    for rule in org_config.PREDICTION_BLOCKING_RULES:
+        assert "org_name_phonetic" not in _splink_rule_column_names(rule)
+
+
+# ---------------------------------------------------------------------------
+# (b) default_blocking_rules() includes the new rule with the correct fields
+# ---------------------------------------------------------------------------
+
+
+def test_default_blocking_rules_includes_org_normalized_state():
+    rules = default_blocking_rules()
+    names = [r.name for r in rules]
+    assert _RULE_NAME in names, f"{_RULE_NAME!r} not in default_blocking_rules(): {names}"
+
+
+def test_default_blocking_rules_org_normalized_state_fields():
+    rules = default_blocking_rules()
+    rule = next(r for r in rules if r.name == _RULE_NAME)
+    assert rule.fields == _RULE_FIELDS, f"Expected {_RULE_FIELDS}, got {rule.fields!r}"
+
+
+# ---------------------------------------------------------------------------
+# (c) blocking_sql._RULE_BLOCK_KEY_SQL has an entry scoped to org/committee
+# ---------------------------------------------------------------------------
+
+
+def test_block_key_sql_has_org_normalized_state():
+    assert _RULE_NAME in _RULE_BLOCK_KEY_SQL, (
+        f"{_RULE_NAME!r} missing from _RULE_BLOCK_KEY_SQL: {list(_RULE_BLOCK_KEY_SQL)}"
+    )
+
+
+def test_block_key_sql_scoped_to_organization_and_committee():
+    sql = _RULE_BLOCK_KEY_SQL[_RULE_NAME]
+    assert "organization" in sql
+    assert "committee" in sql
+
+
+def test_block_key_sql_references_normalized_org_and_state():
+    sql = _RULE_BLOCK_KEY_SQL[_RULE_NAME]
+    assert "normalized_org" in sql
+    assert "ri.state" in sql
+
+
+# ---------------------------------------------------------------------------
+# (d) Functional key_for() checks on BlockingRule
+# ---------------------------------------------------------------------------
+
+
+def _make_row(**kwargs) -> ResolutionInput:
+    defaults = dict(
+        run_id=1,
+        source_type="unified_committee",
+        source_id="C1",
+        entity_type="committee",
+        raw_name="Acme PAC",
+        raw_address="123 Main St",
+    )
+    defaults.update(kwargs)
+    return ResolutionInput(**defaults)
+
+
+def test_key_for_returns_normalized_pipe_state_for_org_row():
+    rule = BlockingRule(name=_RULE_NAME, fields=_RULE_FIELDS)
+    row = _make_row(normalized_org="ACME PAC", state="TX")
+    assert rule.key_for(row) == "acme pac|tx"
+
+
+def test_key_for_returns_none_when_normalized_org_missing():
+    rule = BlockingRule(name=_RULE_NAME, fields=_RULE_FIELDS)
+    assert rule.key_for(_make_row(normalized_org=None, state="TX")) is None
+
+
+def test_key_for_returns_none_when_state_missing():
+    rule = BlockingRule(name=_RULE_NAME, fields=_RULE_FIELDS)
+    assert rule.key_for(_make_row(normalized_org="ACME PAC", state=None)) is None
+
+
+def test_key_for_returns_none_when_normalized_org_blank():
+    rule = BlockingRule(name=_RULE_NAME, fields=_RULE_FIELDS)
+    assert rule.key_for(_make_row(normalized_org="   ", state="TX")) is None
+
+
+def test_key_for_returns_none_when_state_blank():
+    rule = BlockingRule(name=_RULE_NAME, fields=_RULE_FIELDS)
+    assert rule.key_for(_make_row(normalized_org="ACME PAC", state="  ")) is None
+
+
+def test_key_for_normalizes_to_lowercase():
+    rule = BlockingRule(name=_RULE_NAME, fields=_RULE_FIELDS)
+    key = rule.key_for(_make_row(normalized_org="ACME PAC", state="TX"))
+    assert key == key.lower()


### PR DESCRIPTION
Wave 3 of the **review-response-2026-06-07** remediation pack (resolution quality).

> **Base = `resolve/score-stage-scale`** (not main): Wave 3's score.py integration fix builds on that branch's `_row_to_dict`, so this PR is stacked to show only the Wave 3 diff. Retarget to `main` once the base merges.

## Changes
- **Employer as a Splink comparison signal** (never a blocking key — employers change over time): `ResolutionInput.employer` (normalized via `normalize_org_name`), `person.py` `JaroWinklerAtThresholds("employer", [0.88])`, exposed in `score._row_to_dict` (string-dtype cast so an all-NULL batch types VARCHAR, else `jaro_winkler` fails to bind). EM re-estimates m/u (exact-match bf=10.78).
- **Org cross-role blocking — corrected on measured evidence.** The spec's `block_on(org_name_phonetic, state)` exploded org candidate pairs **~9,200×** on real spike data (34.1M vs 3.7k; org_name_phonetic is only the first-token phonetic, state is TX-dominated). Per the pack's >5× guardrail, replaced with `block_on(normalized_org, state)` (~1.2×), in lock-step across `organization.py`, `blocking.py`, `blocking_sql.py`. Fuzzy variants still caught by the org JaroWinkler at scoring time.
- **Employer survivorship**: `CanonicalEntity.employer` scalar (most-recent record) + `provenance_json["employer_history"]` (per-distinct-employer first/last seen). No `CanonicalEmployerHistory` table.

## Evidence
Full suite 903 passed / 0 failed; golden tests pass (no rebaseline); new tests: employer-signal (8), org-blocking (13), employer-survivorship (15). Org pair-count + EM m/u measured on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #30 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #31 
<!-- GitButler Footer Boundary Bottom -->

