### PR TITLE
Vectorized ingest foundation (P1): package, parse-parity primitives, dispatcher

### DIFF
--- a/app/core/ingest_vectorized/__init__.py
+++ b/app/core/ingest_vectorized/__init__.py
@@ -1,0 +1,13 @@
+"""Vectorized (Polars + bulk-write) ingest engine.
+
+A parallel ingest path to the per-row ORM loader, gated by the equivalence harness
+(`app/core/ingest_equivalence.py`): it ships only when
+``diff_snapshots(orm_snapshot, vectorized_snapshot) == []``.
+
+See docs/design/vectorized-ingest-plan.md.
+"""
+from __future__ import annotations
+
+from app.core.ingest_vectorized.dispatcher import run_vectorized
+
+__all__ = ["run_vectorized"]

--- a/app/core/ingest_vectorized/__init__.py
+++ b/app/core/ingest_vectorized/__init__.py
@@ -6,6 +6,7 @@ A parallel ingest path to the per-row ORM loader, gated by the equivalence harne
 
 See docs/design/vectorized-ingest-plan.md.
 """
+
 from __future__ import annotations
 
 from app.core.ingest_vectorized.dispatcher import run_vectorized

--- a/app/core/ingest_vectorized/common.py
+++ b/app/core/ingest_vectorized/common.py
@@ -1,0 +1,121 @@
+"""Shared primitives for the vectorized (Polars) ingest engine.
+
+Pure-Polars column expressions that reproduce the ORM parse helpers EXACTLY, plus a
+dialect-safe bulk write helper. The equivalence harness
+(`app/core/ingest_equivalence.py`) is the gate: any divergence from the ORM output is
+a bug. HARD RULE: no ``map_elements`` / ``apply`` (per-row Python UDF) — everything
+here is a native expression so it runs in Polars' Rust engine.
+
+Two parse dialects exist in the ORM and must be kept distinct:
+- ``tec_*`` mirrors ``app/core/source_models/reports_ingest.py`` (`_parse_amount`
+  strips only ``,``/``$``; `_parse_date` handles 8-digit yyyymmdd + a>31/c>31 sep
+  heuristic, NO year guard).
+- ``builder_*`` mirrors ``app/core/builders.py`` (`_parse_amount` regex-strips
+  ``[^\\d.-]``; `_parse_date` tries a format list with a 1900-2100 year guard).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+
+def clean_str(col: str) -> pl.Expr:
+    """Strip; empty -> null. Mirrors ``_optional_str``."""
+    s = pl.col(col).cast(pl.Utf8).str.strip_chars()
+    return pl.when(s.str.len_chars() > 0).then(s).otherwise(None)
+
+
+# ── amounts ──────────────────────────────────────────────────────────────────
+#: A string Python's Decimal() accepts in TEC data: optional sign, digits with an
+#: optional fractional part, or a leading-dot fraction. Guards against Polars'
+#: lenient cast (e.g. "." -> 0) so we match Decimal()'s ValueError -> None.
+_DECIMAL_RE = r"^-?\d+(\.\d*)?$|^-?\.\d+$"
+
+
+def tec_amount(col: str) -> pl.Expr:
+    """Mirror reports_ingest._parse_amount: strip, remove ',' and '$', Decimal else null."""
+    s = pl.col(col).cast(pl.Utf8).str.strip_chars()
+    cleaned = s.str.replace_all(",", "", literal=True).str.replace_all("$", "", literal=True)
+    return (
+        pl.when((s.str.len_chars() > 0) & cleaned.str.contains(_DECIMAL_RE))
+        .then(cleaned.cast(pl.Decimal(38, 4), strict=False))
+        .otherwise(None)
+    )
+
+
+def builder_amount(col: str) -> pl.Expr:
+    """Mirror builders._parse_amount: strip everything except [0-9.-], then Decimal."""
+    s = pl.col(col).cast(pl.Utf8).str.replace_all(r"[^\d.-]", "")
+    cleaned = pl.when(s.is_in(["", ".", "-", "-.", "."]).not_() & s.is_not_null()).then(s).otherwise(None)
+    return cleaned.cast(pl.Decimal(38, 4), strict=False)
+
+
+# ── dates ────────────────────────────────────────────────────────────────────
+_TEC_FALLBACK_FORMATS = ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y", "%Y/%m/%d")
+
+
+def tec_date(col: str) -> pl.Expr:
+    """Mirror reports_ingest._parse_date.
+
+    8-digit yyyymmdd first; otherwise a separator split where a>31 => (a,b,c) and
+    c>31 => (c,a,b). No 1900-2100 guard (matches the source).
+    """
+    s = pl.col(col).cast(pl.Utf8).str.strip_chars()
+    eight = (s.str.len_chars() == 8) & s.str.contains(r"^\d{8}$")
+    d8 = s.str.to_date("%Y%m%d", strict=False)
+    # Separator forms: try ISO (a>31) then US (c>31). Polars to_date handles validity.
+    iso = s.str.to_date("%Y-%m-%d", strict=False).fill_null(s.str.to_date("%Y/%m/%d", strict=False))
+    us = s.str.to_date("%m/%d/%Y", strict=False).fill_null(s.str.to_date("%m-%d-%Y", strict=False))
+    return (
+        pl.when(s.is_null() | (s.str.len_chars() == 0)).then(None)
+        .when(eight).then(d8)
+        .otherwise(iso.fill_null(us))
+    )
+
+
+def builder_date(col: str) -> pl.Expr:
+    """Mirror builders._parse_date: format list (yyyymmdd first), 1900-2100 guard."""
+    s = pl.col(col).cast(pl.Utf8).str.strip_chars()
+    parsed = s.str.to_date("%Y%m%d", strict=False)
+    for fmt in _TEC_FALLBACK_FORMATS:
+        parsed = parsed.fill_null(s.str.to_date(fmt, strict=False))
+    parsed = parsed.fill_null(s.str.to_datetime("%m/%d/%Y %H:%M:%S", strict=False).dt.date())
+    parsed = parsed.fill_null(s.str.to_datetime("%Y-%m-%dT%H:%M:%S", strict=False).dt.date())
+    return pl.when(parsed.dt.year().is_between(1900, 2100)).then(parsed).otherwise(None)
+
+
+# ── booleans ─────────────────────────────────────────────────────────────────
+def bool_expr(col: str) -> pl.Expr:
+    """Mirror builders._parse_boolean: true set {true,yes,y,1,t}; null/other -> False."""
+    s = pl.col(col).cast(pl.Utf8).str.strip_chars().str.to_lowercase()
+    return s.is_in(["true", "yes", "y", "1", "t"]).fill_null(False)
+
+
+# ── provenance ───────────────────────────────────────────────────────────────
+def raw_json_expr(columns: list[str], alias: str = "raw_data") -> pl.Expr:
+    """JSON-encode the original columns as provenance. Compared structurally (not
+    byte-exact) by the harness, since json.dumps and Polars differ on separators."""
+    return pl.struct([pl.col(c) for c in columns]).struct.json_encode().alias(alias)
+
+
+# ── writes ───────────────────────────────────────────────────────────────────
+def write_frame(
+    session: Any,
+    model: type,
+    frame: pl.DataFrame,
+    *,
+    conflict_cols: list[str],
+    update_cols: list[str] | None = None,
+) -> int:
+    """Bulk upsert a Polars frame into ``model``'s table (dialect-safe).
+
+    Correctness-first via ``app.core.upsert.bulk_upsert`` (works on sqlite + postgres).
+    The Postgres COPY fast-path is a separate perf follow-up.
+    """
+    from app.core.upsert import bulk_upsert
+
+    if frame.is_empty():
+        return 0
+    rows = frame.to_dicts()
+    return bulk_upsert(session, model, rows, conflict_cols=conflict_cols, update_cols=update_cols)

--- a/app/core/ingest_vectorized/common.py
+++ b/app/core/ingest_vectorized/common.py
@@ -18,6 +18,7 @@ Two parse dialects exist in the ORM and must be kept distinct:
 - ``builder_*`` mirrors ``app/core/builders.py`` (`_parse_amount` regex-strips
   ``[^\\d.-]``; `_parse_date` tries a format list with a 1900-2100 year guard).
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -57,7 +58,9 @@ def tec_amount(col: str) -> pl.Expr:
 def builder_amount(col: str) -> pl.Expr:
     """Mirror builders._parse_amount: strip everything except [0-9.-], then Decimal."""
     s = pl.col(col).cast(pl.Utf8).str.replace_all(r"[^\d.-]", "")
-    cleaned = pl.when(s.is_in(["", ".", "-", "-.", "."]).not_() & s.is_not_null()).then(s).otherwise(None)
+    cleaned = (
+        pl.when(s.is_in(["", ".", "-", "-.", "."]).not_() & s.is_not_null()).then(s).otherwise(None)
+    )
     return cleaned.cast(pl.Decimal(38, 4), strict=False)
 
 
@@ -83,8 +86,10 @@ def tec_date(col: str) -> pl.Expr:
     iso = s.str.to_date("%Y-%m-%d", strict=False).fill_null(s.str.to_date("%Y/%m/%d", strict=False))
     us = s.str.to_date("%m/%d/%Y", strict=False).fill_null(s.str.to_date("%m-%d-%Y", strict=False))
     return (
-        pl.when(s.is_null() | (s.str.len_chars() == 0)).then(None)
-        .when(eight).then(d8)
+        pl.when(s.is_null() | (s.str.len_chars() == 0))
+        .then(None)
+        .when(eight)
+        .then(d8)
         .otherwise(iso.fill_null(us))
     )
 

--- a/app/core/ingest_vectorized/common.py
+++ b/app/core/ingest_vectorized/common.py
@@ -1,10 +1,15 @@
 """Shared primitives for the vectorized (Polars) ingest engine.
 
-Pure-Polars column expressions that reproduce the ORM parse helpers EXACTLY, plus a
-dialect-safe bulk write helper. The equivalence harness
-(`app/core/ingest_equivalence.py`) is the gate: any divergence from the ORM output is
-a bug. HARD RULE: no ``map_elements`` / ``apply`` (per-row Python UDF) — everything
-here is a native expression so it runs in Polars' Rust engine.
+Pure-Polars column expressions that reproduce the ORM parse helpers on **real
+TEC-shaped inputs** (currency strings, yyyymmdd / sep dates), plus a dialect-safe bulk
+write helper. The equivalence harness (`app/core/ingest_equivalence.py`) is the gate:
+divergence on real data is a bug. HARD RULE: no ``map_elements`` / ``apply`` (per-row
+Python UDF) — everything here is a native expression so it runs in Polars' Rust engine.
+
+Bounded, documented divergences from the ORM on inputs that do NOT occur in TEC data
+(safe; see per-function docstrings): ``tec_amount`` rejects scientific notation /
+Infinity / NaN that ``Decimal()`` would accept; ``tec_date`` returns null (not raise)
+on invalid 8-digit dates where the ORM would raise and reject the row.
 
 Two parse dialects exist in the ORM and must be kept distinct:
 - ``tec_*`` mirrors ``app/core/source_models/reports_ingest.py`` (`_parse_amount`
@@ -34,7 +39,12 @@ _DECIMAL_RE = r"^-?\d+(\.\d*)?$|^-?\.\d+$"
 
 
 def tec_amount(col: str) -> pl.Expr:
-    """Mirror reports_ingest._parse_amount: strip, remove ',' and '$', Decimal else null."""
+    """Mirror reports_ingest._parse_amount: strip, remove ',' and '$', Decimal else null.
+
+    Bounded divergence (safe — absent from TEC currency fields): scientific notation
+    ("1e5"), "Infinity", and "NaN" — which ``Decimal()`` accepts — are rejected to null
+    by the ``_DECIMAL_RE`` guard (which is also what stops Polars casting "." to 0).
+    """
     s = pl.col(col).cast(pl.Utf8).str.strip_chars()
     cleaned = s.str.replace_all(",", "", literal=True).str.replace_all("$", "", literal=True)
     return (
@@ -60,6 +70,11 @@ def tec_date(col: str) -> pl.Expr:
 
     8-digit yyyymmdd first; otherwise a separator split where a>31 => (a,b,c) and
     c>31 => (c,a,b). No 1900-2100 guard (matches the source).
+
+    Bounded divergence: an INVALID 8-digit date (e.g. "20010229", month/day out of
+    range) returns null here, whereas the ORM ``_parse_date`` calls ``date(...)``
+    unguarded and RAISES — which rejects that row at ingest. Callers that require a
+    mandatory date should drop null-date rows so behavior matches the ORM reject.
     """
     s = pl.col(col).cast(pl.Utf8).str.strip_chars()
     eight = (s.str.len_chars() == 8) & s.str.contains(r"^\d{8}$")

--- a/app/core/ingest_vectorized/dispatcher.py
+++ b/app/core/ingest_vectorized/dispatcher.py
@@ -1,0 +1,68 @@
+"""`run_vectorized` — the vectorized ingest entrypoint.
+
+Mirrors `scripts/loaders/production_loader.discover_and_load`: seed reference rows,
+discover source files, then dispatch each registered family worker in FK order. The
+per-family transforms live in `app/core/ingest_vectorized/families/`; importing this
+package registers them.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from app.core.ingest_vectorized.registry import FAMILY_WORKERS, FamilyContext
+from app.logger import Logger
+
+_logger = Logger(__name__)
+
+
+def _seed(session: Any, state: str):
+    """Seed committee_types + the State row (reuse the ORM loader helpers)."""
+    from scripts.loaders.production_loader import _ensure_committee_types, _ensure_state
+
+    _ensure_committee_types(session)
+    return _ensure_state(session, state)
+
+
+def run_vectorized(
+    engine: Any,
+    fixtures_dir: Path | str,
+    *,
+    state: str = "texas",
+) -> dict[str, int]:
+    """Vectorized ingest of *state* source files under *fixtures_dir* into *engine*.
+
+    Returns counters: ``{discovered, loaded, families_run}``. Families register
+    themselves on import; each is run in ascending ``priority`` (FK order).
+    """
+    from sqlmodel import Session
+
+    # Import families for their registration side effect (deferred to avoid cycles).
+    from app.core.ingest_vectorized import families  # noqa: F401
+    from scripts.loaders.file_discovery import discover_state_files
+
+    fixtures_dir = Path(fixtures_dir)
+    discovered = discover_state_files(state, base_dir=fixtures_dir)
+    by_type: dict[str, list[Path]] = {}
+    for item in discovered:
+        by_type.setdefault(item.record_type, []).append(item.path)
+
+    counts = {"discovered": len(discovered), "loaded": 0, "families_run": 0}
+    session = Session(engine, expire_on_commit=False)
+    try:
+        state_row = _seed(session, state)
+        ctx = FamilyContext(
+            session=session, engine=engine, state_id=state_row.id,
+            state_code=state_row.code, state=state,
+        )
+        for worker in sorted(FAMILY_WORKERS, key=lambda w: w.priority):
+            files = [p for rt in worker.record_types for p in by_type.get(rt, [])]
+            if not files:
+                continue
+            result = worker.run(files, ctx)
+            counts["loaded"] += int(result.get("loaded", 0))
+            counts["families_run"] += 1
+            _logger.info(f"[vectorized] family {sorted(worker.record_types)} -> {result}")
+    finally:
+        session.close()
+    return counts

--- a/app/core/ingest_vectorized/dispatcher.py
+++ b/app/core/ingest_vectorized/dispatcher.py
@@ -5,6 +5,7 @@ discover source files, then dispatch each registered family worker in FK order. 
 per-family transforms live in `app/core/ingest_vectorized/families/`; importing this
 package registers them.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -52,8 +53,11 @@ def run_vectorized(
     try:
         state_row = _seed(session, state)
         ctx = FamilyContext(
-            session=session, engine=engine, state_id=state_row.id,
-            state_code=state_row.code, state=state,
+            session=session,
+            engine=engine,
+            state_id=state_row.id,
+            state_code=state_row.code,
+            state=state,
         )
         for worker in sorted(FAMILY_WORKERS, key=lambda w: w.priority):
             files = [p for rt in worker.record_types for p in by_type.get(rt, [])]

--- a/app/core/ingest_vectorized/families/__init__.py
+++ b/app/core/ingest_vectorized/families/__init__.py
@@ -1,0 +1,10 @@
+"""Per-record-type family workers for the vectorized ingest engine.
+
+Each family module registers its worker (via `registry.register`) on import. Phase B
+adds: reports (CVR1/FINL), refs (FILER/lookups), flat_txns (RCPT/EXPN),
+detail_children (LOAN/DEBT/...), cand. Importing this package imports them all.
+"""
+from __future__ import annotations
+
+# Family modules are imported here as they land so the dispatcher registers them, e.g.:
+#   from app.core.ingest_vectorized.families import reports  # noqa: F401

--- a/app/core/ingest_vectorized/families/__init__.py
+++ b/app/core/ingest_vectorized/families/__init__.py
@@ -4,6 +4,7 @@ Each family module registers its worker (via `registry.register`) on import. Pha
 adds: reports (CVR1/FINL), refs (FILER/lookups), flat_txns (RCPT/EXPN),
 detail_children (LOAN/DEBT/...), cand. Importing this package imports them all.
 """
+
 from __future__ import annotations
 
 # Family modules are imported here as they land so the dispatcher registers them, e.g.:

--- a/app/core/ingest_vectorized/registry.py
+++ b/app/core/ingest_vectorized/registry.py
@@ -1,0 +1,50 @@
+"""Family-worker registry for the vectorized ingest engine.
+
+Each record-type family registers a worker that transforms its source files into
+unified rows. Mirrors `app/core/source_models/__init__.py::RECORD_TYPE_BUILDERS`,
+but workers operate on whole frames (Polars) rather than per-row.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class FamilyContext:
+    """Shared per-run context handed to every family worker."""
+
+    session: Any
+    engine: Any
+    state_id: int
+    state_code: str
+    state: str = "texas"
+    # Shared dim id-maps (committees/persons/entities/addresses) populated by the
+    # foundation so families resolve FKs without re-deduping. Filled in later phases.
+    dims: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class FamilyWorker(Protocol):
+    """A vectorized worker for one record-type family."""
+
+    #: Record types this worker handles (e.g. {"CVR1", "FINL"}).
+    record_types: frozenset[str]
+    #: Lower = earlier (FK ordering), mirroring production_loader._FILE_PRIORITY.
+    priority: int
+
+    def run(self, files: list[Path], ctx: FamilyContext) -> dict[str, int]:
+        """Transform + persist this family's files. Returns counters."""
+        ...
+
+
+# Populated by `register()` as family modules are imported.
+FAMILY_WORKERS: list[FamilyWorker] = []
+
+
+def register(worker: FamilyWorker) -> FamilyWorker:
+    """Register a family worker (idempotent by type identity)."""
+    if not any(type(w) is type(worker) for w in FAMILY_WORKERS):
+        FAMILY_WORKERS.append(worker)
+    return worker

--- a/app/core/ingest_vectorized/registry.py
+++ b/app/core/ingest_vectorized/registry.py
@@ -4,6 +4,7 @@ Each record-type family registers a worker that transforms its source files into
 unified rows. Mirrors `app/core/source_models/__init__.py::RECORD_TYPE_BUILDERS`,
 but workers operate on whole frames (Polars) rather than per-row.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/tests/ingest_equivalence/test_vectorized_parse.py
+++ b/tests/ingest_equivalence/test_vectorized_parse.py
@@ -1,0 +1,84 @@
+"""Parity proof for the vectorized parse expressions vs the ORM parse helpers.
+
+These are the hardest primitives of the vectorized engine — if a Polars expression
+diverges from the ORM helper on any input, the row-for-row equivalence gate fails.
+We assert exact equality across a battery of inputs (incl. TEC edge cases).
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import polars as pl
+
+from app.core.builders import UnifiedSQLModelBuilder
+from app.core.ingest_vectorized import common
+from app.core.source_models import reports_ingest as ri
+
+# Shared ORM builder for the builders.py-dialect helpers.
+_B = UnifiedSQLModelBuilder("texas", 1, "TX")
+
+AMOUNT_INPUTS = [
+    None, "", "  ", "0", "90", "90.00", "1000.00", "1,000.00", "$1,000.00",
+    "$1,234,567.89", "-50.5", "abc", "Prime Rate", "NONE", ".", "-", "12.5%",
+]
+# Clean, well-defined dates for the tec_* dialect (its ORM helper RAISES on
+# malformed 8-digit input like "20001305", so such values can't be parity-tested
+# here — they reject the row at ingest, an edge absent from clean TEC data).
+TEC_DATE_INPUTS = [
+    None, "", "  ", "20000705", "20120229", "2000-07-05", "07/05/2000",
+    "2000/07/05", "07-05-2000", "garbage",
+]
+# builders._parse_date is total (returns None on bad input) so it can take more.
+DATE_INPUTS = TEC_DATE_INPUTS + ["00041110", "20001305"]
+BOOL_INPUTS = [None, "", "Y", "y", "N", "true", "TRUE", "false", "1", "0", "t", "x"]
+
+
+def _apply(expr_fn, inputs) -> list:
+    df = pl.DataFrame({"v": [None if x is None else str(x) for x in inputs]}, schema={"v": pl.Utf8})
+    return df.select(expr_fn("v").alias("out"))["out"].to_list()
+
+
+def _eq_amount(a, b) -> bool:
+    if a is None or b is None:
+        return a is None and b is None
+    return Decimal(str(a)) == Decimal(str(b))
+
+
+def test_tec_amount_matches_reports_ingest():
+    got = _apply(common.tec_amount, AMOUNT_INPUTS)
+    want = [ri._parse_amount(x) for x in AMOUNT_INPUTS]
+    for inp, g, w in zip(AMOUNT_INPUTS, got, want):
+        assert _eq_amount(g, w), f"tec_amount({inp!r}): got {g!r} want {w!r}"
+
+
+def test_tec_date_matches_reports_ingest():
+    got = _apply(common.tec_date, TEC_DATE_INPUTS)
+    want = [ri._parse_date(x) for x in TEC_DATE_INPUTS]
+    for inp, g, w in zip(TEC_DATE_INPUTS, got, want):
+        assert g == w, f"tec_date({inp!r}): got {g!r} want {w!r}"
+
+
+def test_builder_amount_matches_builders():
+    got = _apply(common.builder_amount, AMOUNT_INPUTS)
+    want = [_B._parse_amount(x) for x in AMOUNT_INPUTS]
+    for inp, g, w in zip(AMOUNT_INPUTS, got, want):
+        assert _eq_amount(g, w), f"builder_amount({inp!r}): got {g!r} want {w!r}"
+
+
+def test_builder_date_matches_builders():
+    got = _apply(common.builder_date, DATE_INPUTS)
+    want = [_B._parse_date(x) for x in DATE_INPUTS]
+    for inp, g, w in zip(DATE_INPUTS, got, want):
+        assert g == w, f"builder_date({inp!r}): got {g!r} want {w!r}"
+
+
+def test_bool_expr_matches_builders():
+    got = _apply(common.bool_expr, BOOL_INPUTS)
+    want = [_B._parse_boolean(x) for x in BOOL_INPUTS]
+    for inp, g, w in zip(BOOL_INPUTS, got, want):
+        assert bool(g) == bool(w), f"bool_expr({inp!r}): got {g!r} want {w!r}"
+
+
+def test_clean_str_strips_and_nulls_empty():
+    got = _apply(common.clean_str, [None, "", "  ", " x ", "abc"])
+    assert got == [None, None, None, "x", "abc"]

--- a/tests/ingest_equivalence/test_vectorized_parse.py
+++ b/tests/ingest_equivalence/test_vectorized_parse.py
@@ -4,6 +4,7 @@ These are the hardest primitives of the vectorized engine — if a Polars expres
 diverges from the ORM helper on any input, the row-for-row equivalence gate fails.
 We assert exact equality across a battery of inputs (incl. TEC edge cases).
 """
+
 from __future__ import annotations
 
 from decimal import Decimal
@@ -18,15 +19,38 @@ from app.core.source_models import reports_ingest as ri
 _B = UnifiedSQLModelBuilder("texas", 1, "TX")
 
 AMOUNT_INPUTS = [
-    None, "", "  ", "0", "90", "90.00", "1000.00", "1,000.00", "$1,000.00",
-    "$1,234,567.89", "-50.5", "abc", "Prime Rate", "NONE", ".", "-", "12.5%",
+    None,
+    "",
+    "  ",
+    "0",
+    "90",
+    "90.00",
+    "1000.00",
+    "1,000.00",
+    "$1,000.00",
+    "$1,234,567.89",
+    "-50.5",
+    "abc",
+    "Prime Rate",
+    "NONE",
+    ".",
+    "-",
+    "12.5%",
 ]
 # Clean, well-defined dates for the tec_* dialect (its ORM helper RAISES on
 # malformed 8-digit input like "20001305", so such values can't be parity-tested
 # here — they reject the row at ingest, an edge absent from clean TEC data).
 TEC_DATE_INPUTS = [
-    None, "", "  ", "20000705", "20120229", "2000-07-05", "07/05/2000",
-    "2000/07/05", "07-05-2000", "garbage",
+    None,
+    "",
+    "  ",
+    "20000705",
+    "20120229",
+    "2000-07-05",
+    "07/05/2000",
+    "2000/07/05",
+    "07-05-2000",
+    "garbage",
 ]
 # builders._parse_date is total (returns None on bad input) so it can take more.
 DATE_INPUTS = TEC_DATE_INPUTS + ["00041110", "20001305"]

--- a/tests/ingest_equivalence/test_vectorized_write_frame.py
+++ b/tests/ingest_equivalence/test_vectorized_write_frame.py
@@ -1,4 +1,5 @@
 """Smoke test for common.write_frame — the Polars-frame -> bulk_upsert -> DB glue."""
+
 from __future__ import annotations
 
 import polars as pl
@@ -35,7 +36,9 @@ def test_write_frame_is_idempotent_on_conflict():
         s.commit()
         # Re-write with an updated description -> upsert, no duplicate row.
         frame2 = pl.DataFrame({"code": ["A1"], "description": ["Advertising (rev)"]})
-        write_frame(s, ExpenditureCategory, frame2, conflict_cols=["code"], update_cols=["description"])
+        write_frame(
+            s, ExpenditureCategory, frame2, conflict_cols=["code"], update_cols=["description"]
+        )
         s.commit()
         rows = s.exec(select(ExpenditureCategory)).all()
     assert len(rows) == 1
@@ -44,6 +47,8 @@ def test_write_frame_is_idempotent_on_conflict():
 
 def test_write_frame_empty_is_noop():
     engine = _engine()
-    empty = pl.DataFrame({"code": [], "description": []}, schema={"code": pl.Utf8, "description": pl.Utf8})
+    empty = pl.DataFrame(
+        {"code": [], "description": []}, schema={"code": pl.Utf8, "description": pl.Utf8}
+    )
     with Session(engine, expire_on_commit=False) as s:
         assert write_frame(s, ExpenditureCategory, empty, conflict_cols=["code"]) == 0

--- a/tests/ingest_equivalence/test_vectorized_write_frame.py
+++ b/tests/ingest_equivalence/test_vectorized_write_frame.py
@@ -1,0 +1,49 @@
+"""Smoke test for common.write_frame — the Polars-frame -> bulk_upsert -> DB glue."""
+from __future__ import annotations
+
+import polars as pl
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.core import models  # noqa: F401 — register tables
+from app.core.ingest_vectorized.common import write_frame
+from app.core.source_models import ExpenditureCategory  # noqa: F401
+
+
+def _engine():
+    engine = create_engine("sqlite://")
+    tables = [t for t in SQLModel.metadata.tables.values() if t.schema is None]
+    SQLModel.metadata.create_all(engine, tables=list(tables))
+    return engine
+
+
+def test_write_frame_inserts_rows():
+    engine = _engine()
+    frame = pl.DataFrame({"code": ["A1", "B2"], "description": ["Advertising", "Bank fees"]})
+    with Session(engine, expire_on_commit=False) as s:
+        n = write_frame(s, ExpenditureCategory, frame, conflict_cols=["code"])
+        s.commit()
+        rows = s.exec(select(ExpenditureCategory)).all()
+    assert n == 2
+    assert {r.code: r.description for r in rows} == {"A1": "Advertising", "B2": "Bank fees"}
+
+
+def test_write_frame_is_idempotent_on_conflict():
+    engine = _engine()
+    frame = pl.DataFrame({"code": ["A1"], "description": ["Advertising"]})
+    with Session(engine, expire_on_commit=False) as s:
+        write_frame(s, ExpenditureCategory, frame, conflict_cols=["code"])
+        s.commit()
+        # Re-write with an updated description -> upsert, no duplicate row.
+        frame2 = pl.DataFrame({"code": ["A1"], "description": ["Advertising (rev)"]})
+        write_frame(s, ExpenditureCategory, frame2, conflict_cols=["code"], update_cols=["description"])
+        s.commit()
+        rows = s.exec(select(ExpenditureCategory)).all()
+    assert len(rows) == 1
+    assert rows[0].description == "Advertising (rev)"
+
+
+def test_write_frame_empty_is_noop():
+    engine = _engine()
+    empty = pl.DataFrame({"code": [], "description": []}, schema={"code": pl.Utf8, "description": pl.Utf8})
+    with Session(engine, expire_on_commit=False) as s:
+        assert write_frame(s, ExpenditureCategory, empty, conflict_cols=["code"]) == 0


### PR DESCRIPTION
Phase-A **foundation** for the vectorized/Polars ingest engine (`docs/design/vectorized-ingest-plan.md`), gated by the P0 equivalence harness (#33). Additive — no change to the existing ORM loader.

## What's here
- **`app/core/ingest_vectorized/common.py`** — pure-Polars column expressions that reproduce the ORM parse helpers on real TEC-shaped inputs (**no `map_elements`**): `tec_amount`/`tec_date` (mirror the `reports_ingest` dialect), `builder_amount`/`builder_date` (mirror the `builders` dialect), `bool_expr`, `clean_str`, `raw_json_expr`; plus `write_frame` (dialect-safe `bulk_upsert`). Bounded, documented, TEC-safe divergences (scientific notation; invalid-date null-vs-raise).
- **`registry.py`** — `FamilyWorker` protocol + registry (mirrors `RECORD_TYPE_BUILDERS`).
- **`dispatcher.py`** — `run_vectorized(engine, fixtures_dir, state)`: seed → discover → dispatch families in FK order (no-op until families register).
- **Tests** — `test_vectorized_parse.py` proves each Polars expression is **row-for-row equal to its ORM counterpart** across a battery (incl. edge cases: `.`→None, `$1,000.00`, malformed dates); `test_vectorized_write_frame.py` smoke-tests the frame→bulk_upsert→DB glue (insert/idempotent-upsert/empty).

## Evidence
- 19 `tests/ingest_equivalence` tests pass (10 harness + 9 new); ruff clean (lint + format); **no `map_elements`/`.apply`**; code-reviewer **PASS**.

## Next (Phase B — gated fan-out, separate PRs)
Family workers register behind this foundation, each gated by `diff_snapshots(orm, vec) == []` for its tables: **reports** (CVR1/FINL) → **refs** (FILER/lookups) → **flat_txns** (RCPT/EXPN) → **detail_children** (LOAN/DEBT/…) → **cand**. Postgres COPY perf path is a follow-up (correctness via `bulk_upsert` first).

Builds on #33 (P0 harness, merged). Independent of #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)