### PR TITLE
Vectorized reports family (P1): CVR1/FINL → unified_reports, gated-equivalent

### DIFF
--- a/app/core/ingest_equivalence.py
+++ b/app/core/ingest_equivalence.py
@@ -19,6 +19,7 @@ LIMITATION (v1): junction rows whose only non-volatile columns are surrogate FKs
 their remaining natural columns (role, amount) only — gross differences are caught,
 fine-grained mislinkage is not. P1 may add FK->natural-key resolution.
 """
+
 from __future__ import annotations
 
 from collections import Counter
@@ -44,12 +45,32 @@ VOLATILE_COLUMNS: frozenset[str] = frozenset(
 )
 
 
+# Provenance/JSON columns compared STRUCTURALLY (parse + canonical re-dump), not
+# byte-exact: json.dumps (ORM) and Polars json_encode differ on key order/separators,
+# but the logical content must match.
+JSON_COLUMNS: frozenset[str] = frozenset(
+    {"raw_data", "provenance_json", "metadata_json", "explanation_json", "raw_json", "config_json"}
+)
+
+
+def _canonicalize_json(value: Any) -> Any:
+    """Parse a JSON string and re-dump it canonically (sorted keys, no spaces) so two
+    engines that emit equivalent-but-differently-formatted JSON compare equal. Returns
+    the original value unchanged if it is not parseable JSON."""
+    import json
+
+    if value is None:
+        return None
+    try:
+        return json.dumps(json.loads(value), sort_keys=True, separators=(",", ":"), default=str)
+    except (TypeError, ValueError):
+        return value
+
+
 def _target_tables(inspector: Any) -> list[str]:
     """Unified source-layer + canonical resolve-layer tables present in the DB."""
     names = set(inspector.get_table_names())
-    return sorted(
-        t for t in names if t.startswith("unified_") or t.startswith("canonical_")
-    )
+    return sorted(t for t in names if t.startswith("unified_") or t.startswith("canonical_"))
 
 
 def _surrogate_fk_columns(inspector: Any, table: str) -> set[str]:
@@ -69,9 +90,7 @@ def _comparable_columns(inspector: Any, table: str) -> list[str]:
 
 def _row_key(row: dict[str, Any]) -> tuple[tuple[str, str | None], ...]:
     """A hashable, order-independent key for one row (None distinct from '')."""
-    return tuple(
-        sorted((k, None if v is None else str(v)) for k, v in row.items())
-    )
+    return tuple(sorted((k, None if v is None else str(v)) for k, v in row.items()))
 
 
 def _sort_key(row: dict[str, Any]) -> tuple[str, ...]:
@@ -95,8 +114,12 @@ def snapshot_unified(engine: Engine) -> dict[str, list[dict[str, Any]]]:
             continue
         tbl = Table(table, md, autoload_with=engine)
         stmt = select(*[tbl.c[name] for name in keep])
+        json_cols = [c for c in keep if c in JSON_COLUMNS]
         with engine.connect() as conn:
             rows = [dict(m) for m in conn.execute(stmt).mappings().all()]
+        for row in rows:
+            for col in json_cols:
+                row[col] = _canonicalize_json(row[col])
         rows.sort(key=_sort_key)
         snapshot[table] = rows
     return snapshot

--- a/app/core/ingest_vectorized/common.py
+++ b/app/core/ingest_vectorized/common.py
@@ -120,22 +120,51 @@ def raw_json_expr(columns: list[str], alias: str = "raw_data") -> pl.Expr:
 
 
 # ── writes ───────────────────────────────────────────────────────────────────
+def _inject_auto_columns(model: type, rows: list[dict[str, Any]]) -> None:
+    """Fill ``uuid`` / ``created_at`` / ``updated_at`` that the ORM sets via
+    ``default_factory`` — those Python defaults do NOT fire on a core bulk insert.
+    Values are non-deterministic but are dropped by the equivalence harness
+    (volatile columns); we only need them non-null to satisfy NOT NULL/unique."""
+    import uuid as _uuid
+    from datetime import datetime, timezone
+
+    cols = set(model.__table__.columns.keys())  # type: ignore[attr-defined]
+    now = datetime.now(timezone.utc)
+    for r in rows:
+        if "uuid" in cols and r.get("uuid") is None:
+            r["uuid"] = str(_uuid.uuid4())
+        if "created_at" in cols and r.get("created_at") is None:
+            r["created_at"] = now
+        if "updated_at" in cols and r.get("updated_at") is None:
+            r["updated_at"] = now
+
+
 def write_frame(
     session: Any,
     model: type,
     frame: pl.DataFrame,
     *,
-    conflict_cols: list[str],
+    conflict_cols: list[str] | None,
     update_cols: list[str] | None = None,
 ) -> int:
-    """Bulk upsert a Polars frame into ``model``'s table (dialect-safe).
+    """Bulk-write a Polars frame into ``model``'s table (dialect-safe).
 
-    Correctness-first via ``app.core.upsert.bulk_upsert`` (works on sqlite + postgres).
-    The Postgres COPY fast-path is a separate perf follow-up.
+    With ``conflict_cols`` -> upsert via ``app.core.upsert.bulk_upsert``; with
+    ``conflict_cols=None`` -> plain core insert (for tables without a natural unique
+    key). Auto-fills uuid/timestamps the ORM would set. Correctness-first; the
+    Postgres COPY fast-path is a separate perf follow-up.
     """
+    from sqlalchemy import insert
+
     from app.core.upsert import bulk_upsert
 
     if frame.is_empty():
         return 0
     rows = frame.to_dicts()
-    return bulk_upsert(session, model, rows, conflict_cols=conflict_cols, update_cols=update_cols)
+    _inject_auto_columns(model, rows)
+    if conflict_cols:
+        return bulk_upsert(
+            session, model, rows, conflict_cols=conflict_cols, update_cols=update_cols
+        )
+    session.execute(insert(model.__table__), rows)  # type: ignore[attr-defined]
+    return len(rows)

--- a/app/core/ingest_vectorized/common.py
+++ b/app/core/ingest_vectorized/common.py
@@ -166,5 +166,8 @@ def write_frame(
         return bulk_upsert(
             session, model, rows, conflict_cols=conflict_cols, update_cols=update_cols
         )
+    # Plain insert: commit explicitly (bulk_upsert commits internally; the dispatcher
+    # closes the session in finally with no commit, which would otherwise roll this back).
     session.execute(insert(model.__table__), rows)  # type: ignore[attr-defined]
+    session.commit()
     return len(rows)

--- a/app/core/ingest_vectorized/dispatcher.py
+++ b/app/core/ingest_vectorized/dispatcher.py
@@ -60,10 +60,10 @@ def run_vectorized(
             state=state,
         )
         for worker in sorted(FAMILY_WORKERS, key=lambda w: w.priority):
-            files = [p for rt in worker.record_types for p in by_type.get(rt, [])]
-            if not files:
+            files_by_type = {rt: by_type[rt] for rt in worker.record_types if rt in by_type}
+            if not files_by_type:
                 continue
-            result = worker.run(files, ctx)
+            result = worker.run(files_by_type, ctx)
             counts["loaded"] += int(result.get("loaded", 0))
             counts["families_run"] += 1
             _logger.info(f"[vectorized] family {sorted(worker.record_types)} -> {result}")

--- a/app/core/ingest_vectorized/families/__init__.py
+++ b/app/core/ingest_vectorized/families/__init__.py
@@ -7,5 +7,5 @@ detail_children (LOAN/DEBT/...), cand. Importing this package imports them all.
 
 from __future__ import annotations
 
-# Family modules are imported here as they land so the dispatcher registers them, e.g.:
-#   from app.core.ingest_vectorized.families import reports  # noqa: F401
+# Family modules are imported here as they land so the dispatcher registers them.
+from app.core.ingest_vectorized.families import reports  # noqa: F401

--- a/app/core/ingest_vectorized/families/reports.py
+++ b/app/core/ingest_vectorized/families/reports.py
@@ -1,0 +1,153 @@
+"""Vectorized reports family: CVR1 -> unified_reports, FINL -> is_final update.
+
+Reproduces `app/core/source_models/reports_ingest.py::build_report` +
+`build_final_report` columnar (pure Polars, no map_elements). Gated by
+diff_snapshots restricted to ``unified_reports``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+from sqlalchemy import update
+
+from app.core.ingest_vectorized import common
+from app.core.ingest_vectorized.registry import FamilyContext, register
+from app.core.source_models.reports import UnifiedReport
+
+#: Source columns referenced by the report transform. TEC files omit columns that
+#: are always blank, so any missing one is added as null (mirrors raw.get() -> None).
+_SOURCE_COLS = (
+    "filerIdent",
+    "reportInfoIdent",
+    "formTypeCd",
+    "filedDt",
+    "periodStartDt",
+    "periodEndDt",
+    "totalContribAmount",
+    "unitemizedContribAmount",
+    "totalExpendAmount",
+    "unitemizedExpendAmount",
+    "loanBalanceAmount",
+    "contribsMaintainedAmount",
+    "cashOnHandAmount",
+    "filerName",
+    "treasNameFirst",
+    "treasNameLast",
+    "treasPersentTypeCd",
+    "treasNameOrganization",
+)
+
+
+def _read(files: list[Path]) -> pl.DataFrame | None:
+    frames = [pl.read_parquet(p) for p in files]
+    if not frames:
+        return None
+    return frames[0] if len(frames) == 1 else pl.concat(frames, how="diagonal_relaxed")
+
+
+def _ensure_cols(df: pl.DataFrame, names) -> pl.DataFrame:
+    """Add any referenced source column missing from *df* as a null Utf8 column."""
+    missing = [pl.lit(None, dtype=pl.Utf8).alias(n) for n in names if n not in df.columns]
+    return df.with_columns(missing) if missing else df
+
+
+def _treasurer_expr() -> pl.Expr:
+    """treasPersentTypeCd==ENTITY -> org; else first+last joined skipping blanks."""
+    first = common.clean_str("treasNameFirst")
+    last = common.clean_str("treasNameLast")
+    individual = pl.concat_str([first, last], separator=" ", ignore_nulls=True)
+    individual = pl.when(individual.str.len_chars() > 0).then(individual).otherwise(None)
+    return (
+        pl.when(common.clean_str("treasPersentTypeCd") == "ENTITY")
+        .then(common.clean_str("treasNameOrganization"))
+        .otherwise(individual)
+    )
+
+
+class ReportsWorker:
+    record_types = frozenset({"CVR1", "FINL"})
+    priority = 1
+
+    def run(self, files_by_type: dict[str, list[Path]], ctx: FamilyContext) -> dict[str, int]:
+        loaded = 0
+        cvr1 = _read(files_by_type.get("CVR1", []))
+        if cvr1 is not None:
+            loaded += self._load_reports(cvr1, ctx)
+        finl = _read(files_by_type.get("FINL", []))
+        if finl is not None:
+            self._apply_finl(finl, ctx)
+        return {"loaded": loaded}
+
+    def _load_reports(self, df: pl.DataFrame, ctx: FamilyContext) -> int:
+        orig_cols = df.columns  # raw_data provenance = the ORIGINAL parquet columns
+        df = _ensure_cols(df, _SOURCE_COLS)
+        out = df.with_columns(
+            [
+                pl.lit(ctx.state_id).alias("state_id"),
+                common.clean_str("filerIdent").alias("committee_id"),
+                common.clean_str("reportInfoIdent").alias("report_ident"),
+                common.clean_str("formTypeCd").alias("form_type"),
+                common.tec_date("filedDt").alias("filed_date"),
+                common.tec_date("periodStartDt").alias("period_start"),
+                common.tec_date("periodEndDt").alias("period_end"),
+                pl.lit(False).alias("is_final"),
+                common.tec_amount("totalContribAmount").alias("total_contributions"),
+                common.tec_amount("unitemizedContribAmount").alias(
+                    "total_unitemized_contributions"
+                ),
+                common.tec_amount("totalExpendAmount").alias("total_expenditures"),
+                common.tec_amount("unitemizedExpendAmount").alias("total_unitemized_expenditures"),
+                common.tec_amount("loanBalanceAmount").alias("loan_balance"),
+                common.tec_amount("contribsMaintainedAmount").alias("contributions_maintained"),
+                common.tec_amount("cashOnHandAmount").alias("cash_on_hand"),
+                pl.lit(None).alias("file_origin_id"),
+                common.raw_json_expr(orig_cols, alias="raw_data"),
+                common.clean_str("filerName").alias("committee_name_at_filing"),
+                _treasurer_expr().alias("treasurer_name_at_filing"),
+            ]
+        ).select(
+            "state_id",
+            "committee_id",
+            "report_ident",
+            "form_type",
+            "filed_date",
+            "period_start",
+            "period_end",
+            "is_final",
+            "total_contributions",
+            "total_unitemized_contributions",
+            "total_expenditures",
+            "total_unitemized_expenditures",
+            "loan_balance",
+            "contributions_maintained",
+            "cash_on_hand",
+            "file_origin_id",
+            "raw_data",
+            "committee_name_at_filing",
+            "treasurer_name_at_filing",
+        )
+        # build_report raises (rejects the row) when reportInfoIdent is missing.
+        out = out.filter(pl.col("report_ident").is_not_null())
+        return common.write_frame(ctx.session, UnifiedReport, out, conflict_cols=["report_ident"])
+
+    def _apply_finl(self, df: pl.DataFrame, ctx: FamilyContext) -> None:
+        """FINL sets is_final=True on the matching report (state_id, report_ident)."""
+        idents = (
+            df.select(common.clean_str("reportInfoIdent").alias("ri"))
+            .filter(pl.col("ri").is_not_null())["ri"]
+            .unique()
+            .to_list()
+        )
+        if not idents:
+            return
+        ctx.session.execute(
+            update(UnifiedReport)
+            .where(UnifiedReport.state_id == ctx.state_id, UnifiedReport.report_ident.in_(idents))
+            .values(is_final=True)
+        )
+        ctx.session.commit()
+
+
+register(ReportsWorker())

--- a/app/core/ingest_vectorized/families/reports.py
+++ b/app/core/ingest_vectorized/families/reports.py
@@ -7,6 +7,7 @@ diff_snapshots restricted to ``unified_reports``.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
 
 import polars as pl
@@ -15,6 +16,9 @@ from sqlalchemy import update
 from app.core.ingest_vectorized import common
 from app.core.ingest_vectorized.registry import FamilyContext, register
 from app.core.source_models.reports import UnifiedReport
+from app.logger import Logger
+
+_logger = Logger(__name__)
 
 #: Source columns referenced by the report transform. TEC files omit columns that
 #: are always blank, so any missing one is added as null (mirrors raw.get() -> None).
@@ -47,7 +51,7 @@ def _read(files: list[Path]) -> pl.DataFrame | None:
     return frames[0] if len(frames) == 1 else pl.concat(frames, how="diagonal_relaxed")
 
 
-def _ensure_cols(df: pl.DataFrame, names) -> pl.DataFrame:
+def _ensure_cols(df: pl.DataFrame, names: Iterable[str]) -> pl.DataFrame:
     """Add any referenced source column missing from *df* as a null Utf8 column."""
     missing = [pl.lit(None, dtype=pl.Utf8).alias(n) for n in names if n not in df.columns]
     return df.with_columns(missing) if missing else df
@@ -129,11 +133,26 @@ class ReportsWorker:
             "treasurer_name_at_filing",
         )
         # build_report raises (rejects the row) when reportInfoIdent is missing.
+        before = out.height
         out = out.filter(pl.col("report_ident").is_not_null())
+        dropped = before - out.height
+        if dropped:
+            _logger.warning(
+                "[vectorized.reports] dropped "
+                + str(dropped)
+                + " of "
+                + str(before)
+                + " CVR1 rows with no report ident (ORM rejects these per-row)"
+            )
         return common.write_frame(ctx.session, UnifiedReport, out, conflict_cols=["report_ident"])
 
     def _apply_finl(self, df: pl.DataFrame, ctx: FamilyContext) -> None:
-        """FINL sets is_final=True on the matching report (state_id, report_ident)."""
+        """FINL sets is_final=True on the matching report.
+
+        Scoped by (state_id, report_ident); the ORM build_final_report matches on
+        report_ident alone. Identical in a single-state DB; the state_id scope is a
+        deliberate, safe improvement (won't flip a same-ident report from another state).
+        """
         idents = (
             df.select(common.clean_str("reportInfoIdent").alias("ri"))
             .filter(pl.col("ri").is_not_null())["ri"]

--- a/app/core/ingest_vectorized/registry.py
+++ b/app/core/ingest_vectorized/registry.py
@@ -35,8 +35,8 @@ class FamilyWorker(Protocol):
     #: Lower = earlier (FK ordering), mirroring production_loader._FILE_PRIORITY.
     priority: int
 
-    def run(self, files: list[Path], ctx: FamilyContext) -> dict[str, int]:
-        """Transform + persist this family's files. Returns counters."""
+    def run(self, files_by_type: dict[str, list[Path]], ctx: FamilyContext) -> dict[str, int]:
+        """Transform + persist this family's files, keyed by record type. Returns counters."""
         ...
 
 

--- a/tests/ingest_equivalence/test_harness.py
+++ b/tests/ingest_equivalence/test_harness.py
@@ -28,7 +28,10 @@ from app.core.source_models import (  # noqa: F401 — register Phase-0 tables
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "ingest_golden"
 
 
-def _make_engine(db_path: Path):
+def _make_engine(db_path: Path, *, enforce_fk: bool = True):
+    """Build a file-backed sqlite engine. ``enforce_fk=False`` for per-family gate
+    runs that load only one family (its FK-parent tables aren't populated, but the
+    natural-key FK columns are still compared)."""
     from sqlalchemy import create_engine
 
     engine = create_engine(f"sqlite:///{db_path}")
@@ -36,7 +39,7 @@ def _make_engine(db_path: Path):
     @event.listens_for(engine, "connect")
     def _fk(dbapi_conn, _rec):
         cur = dbapi_conn.cursor()
-        cur.execute("PRAGMA foreign_keys=ON")
+        cur.execute("PRAGMA foreign_keys=ON" if enforce_fk else "PRAGMA foreign_keys=OFF")
         cur.close()
 
     # Only non-schema-qualified tables: a plain create_all on sqlite raises

--- a/tests/ingest_equivalence/test_reports_family.py
+++ b/tests/ingest_equivalence/test_reports_family.py
@@ -1,0 +1,44 @@
+"""Gate: the vectorized reports family == the ORM loader for unified_reports.
+
+Loads the golden fixtures via the ORM loader and via run_vectorized (reports family
+only registered), then asserts diff_snapshots restricted to unified_reports is empty.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.ingest_equivalence import diff_snapshots, snapshot_unified
+from app.core.ingest_vectorized import run_vectorized
+from tests.ingest_equivalence.test_harness import FIXTURES, _load_golden, _make_engine
+
+
+def _reports_only(snap: dict) -> dict:
+    return {"unified_reports": snap.get("unified_reports", [])}
+
+
+def test_reports_family_matches_orm(tmp_path: Path):
+    orm_engine = _make_engine(tmp_path / "orm.db")
+    _load_golden(orm_engine)
+
+    # FK off: this gate loads only the reports family, so committee/file_origin FK
+    # parents aren't populated — the natural-key committee_id is still compared.
+    vec_engine = _make_engine(tmp_path / "vec.db", enforce_fk=False)
+    run_vectorized(vec_engine, FIXTURES)
+
+    orm = _reports_only(snapshot_unified(orm_engine))
+    vec = _reports_only(snapshot_unified(vec_engine))
+
+    assert orm["unified_reports"], "ORM produced no reports — fixture/loader problem"
+    diffs = diff_snapshots(orm, vec)
+    assert diffs == [], "reports diverge from ORM:\n" + "\n".join(diffs)
+
+
+def test_reports_family_sets_is_final_from_finl(tmp_path: Path):
+    """FINL records flip is_final on the matching report (parity with build_final_report)."""
+    vec_engine = _make_engine(tmp_path / "vec.db", enforce_fk=False)
+    run_vectorized(vec_engine, FIXTURES)
+    snap = snapshot_unified(vec_engine)["unified_reports"]
+    assert any(r.get("is_final") in (True, 1) for r in snap), (
+        "expected at least one is_final report from the FINL fixture"
+    )


### PR DESCRIPTION
First **Phase-B family** of the vectorized ingest engine, behind the merged foundation (#34) and gated by the P0 harness (#33).

## What's here
- **`app/core/ingest_vectorized/families/reports.py`** — `ReportsWorker` reproduces `reports_ingest.build_report` + `build_final_report` **columnar, pure Polars (no `map_elements`)**: CVR1 → `unified_reports` (treasurer ENTITY/INDIVIDUAL conditional, `tec_amount`/`tec_date` parse, `raw_data` provenance, missing-column tolerance), FINL flips `is_final` via a parameterized `update()`.
- **`common.write_frame`** — auto-fills `uuid`/`created_at`/`updated_at` (ORM `default_factory` doesn't fire on core inserts); plain-insert mode (with commit) when `conflict_cols is None`.
- **`ingest_equivalence`** — JSON provenance columns (`raw_data`, …) now compared **structurally** (parse + canonical re-dump), so equivalent-but-differently-formatted JSON matches.
- **registry/dispatcher** — workers receive files keyed by record type; **test_harness** gains an `enforce_fk` flag for per-family gate runs.

## Gate (the proof)
`tests/ingest_equivalence/test_reports_family.py`: load golden fixtures via the ORM loader **and** via `run_vectorized`, then assert `diff_snapshots(orm, vec)` restricted to `unified_reports` **== []** (covers amounts, dates, treasurer conditional, FINL `is_final`, and `raw_data`).

## Evidence
- **21** `tests/ingest_equivalence` tests pass; ruff clean; **no `map_elements`/`.apply`**; code-reviewer **APPROVED**.

## Follow-up (non-blocking)
Add a dedicated unit test for the `write_frame(conflict_cols=None)` plain-insert commit path (reports uses the upsert path; the plain path is exercised by future families).

Stacked on #34 (foundation); diff vs `main` is the 8 reports files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reports data processing capability to the vectorized ingest pipeline.

* **Bug Fixes**
  * Improved JSON data normalization to ensure consistent comparison across systems.
  * Enhanced write operations to support flexible insert modes.

* **Tests**
  * Added comprehensive tests for reports ingest consistency validation.
  * Improved test configuration for data integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->