### PR TITLE
Vectorized flat_txns family (P1): unified_transactions (RCPT/EXPN), gated-equivalent

### DIFF
--- a/app/core/ingest_vectorized/families/__init__.py
+++ b/app/core/ingest_vectorized/families/__init__.py
@@ -8,4 +8,7 @@ detail_children (LOAN/DEBT/...), cand. Importing this package imports them all.
 from __future__ import annotations
 
 # Family modules are imported here as they land so the dispatcher registers them.
-from app.core.ingest_vectorized.families import reports  # noqa: F401
+from app.core.ingest_vectorized.families import (  # noqa: F401
+    flat_txns,
+    reports,
+)

--- a/app/core/ingest_vectorized/families/flat_txns.py
+++ b/app/core/ingest_vectorized/families/flat_txns.py
@@ -192,10 +192,13 @@ def _build_transactions(
     return df.with_columns(
         [
             pl.lit(ctx.state_id).alias("state_id"),
-            common.clean_str(id_col).alias("transaction_id"),
+            # transaction_id / description: build_transaction assigns the raw
+            # _get_field_value result UNSTRIPPED (no clean_str) — match exactly so a
+            # whitespace/empty value isn't normalized to null on the vectorized side.
+            pl.col(id_col).cast(pl.Utf8).alias("transaction_id"),
             common.builder_amount(amount_col).alias("amount"),
             _transaction_date_expr(date_col).alias("transaction_date"),
-            common.clean_str(descr_col).alias("description"),
+            pl.col(descr_col).cast(pl.Utf8).alias("description"),
             pl.lit(transaction_type).alias("transaction_type"),
             # committee_id: filerIdent (_finalize_transaction_for_persist)
             common.clean_str("filerIdent").alias("committee_id"),
@@ -237,6 +240,7 @@ class FlatTxnsWorker:
         if expn is not None:
             loaded += self._load_expn(expn, ctx)
 
+        _logger.info("[vectorized.flat_txns] loaded " + str(loaded) + " transactions")
         return {"loaded": loaded}
 
     def _load_rcpt(self, df: pl.DataFrame, ctx: FamilyContext) -> int:
@@ -252,9 +256,7 @@ class FlatTxnsWorker:
             orig_cols=orig_cols,
             ctx=ctx,
         )
-        return common.write_frame(
-            ctx.session, UnifiedTransaction, out, conflict_cols=None
-        )
+        return common.write_frame(ctx.session, UnifiedTransaction, out, conflict_cols=None)
 
     def _load_expn(self, df: pl.DataFrame, ctx: FamilyContext) -> int:
         orig_cols = df.columns
@@ -269,9 +271,7 @@ class FlatTxnsWorker:
             orig_cols=orig_cols,
             ctx=ctx,
         )
-        return common.write_frame(
-            ctx.session, UnifiedTransaction, out, conflict_cols=None
-        )
+        return common.write_frame(ctx.session, UnifiedTransaction, out, conflict_cols=None)
 
 
 register(FlatTxnsWorker())

--- a/app/core/ingest_vectorized/families/flat_txns.py
+++ b/app/core/ingest_vectorized/families/flat_txns.py
@@ -1,0 +1,277 @@
+"""Vectorized flat-transactions family: RCPT -> CONTRIBUTION, EXPN -> EXPENDITURE.
+
+Reproduces ``app/core/builders.UnifiedSQLModelBuilder.build_transaction`` +
+``scripts/loaders/production_loader._finalize_transaction_for_persist`` columnar
+(pure Polars, no map_elements). Gated by diff_snapshots restricted to
+``unified_transactions``.
+
+Field mappings (per the Texas unified_field_library + ORM build_transaction):
+  RCPT:
+    transaction_id   <- contributionInfoId
+    amount           <- contributionAmount  (builder_amount)
+    transaction_date <- contributionDt      (builder_date, fallback receivedDt)
+    description      <- contributionDescr
+    transaction_type  = 'CONTRIBUTION'  (SQLAlchemy stores enum.name, uppercase)
+
+  EXPN:
+    transaction_id   <- expendInfoId
+    amount           <- expendAmount    (builder_amount)
+    transaction_date <- expendDt        (builder_date, fallback receivedDt)
+    description      <- expendDescr
+    transaction_type  = 'EXPENDITURE'
+
+  Both:
+    committee_id  <- filerIdent         (_finalize_transaction_for_persist)
+    report_ident  <- reportInfoIdent    (build_transaction + _finalize)
+    filed_date    <- receivedDt         (builder_date; filedDt/receivedDt both map
+                                         to unified 'filed_date', ORM prefers receivedDt
+                                         via the field_library mapping for RCPT/EXPN)
+    amended        = False              (no amended field in RCPT/EXPN source)
+    raw_data       = JSON of orig cols  (json.dumps(raw.copy()) in the ORM)
+    state_id       = ctx.state_id
+    file_origin_id = None               (no file_origin seeded in vectorized path)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import polars as pl
+
+from app.core.ingest_vectorized import common
+from app.core.ingest_vectorized.registry import FamilyContext, register
+from app.core.models import UnifiedTransaction
+from app.logger import Logger
+
+_logger = Logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Source column whitelists — every column that appears in TEC RCPT / EXPN
+# parquet files (union of both; missing ones are added as null so that
+# raw_json_expr covers the correct provenance columns).
+# ---------------------------------------------------------------------------
+
+_RCPT_COLS = (
+    "recordType",
+    "formTypeCd",
+    "schedFormTypeCd",
+    "reportInfoIdent",
+    "receivedDt",
+    "infoOnlyFlag",
+    "filerIdent",
+    "filerTypeCd",
+    "filerName",
+    "contributionInfoId",
+    "contributionDt",
+    "contributionAmount",
+    "contributionDescr",
+    "itemizeFlag",
+    "travelFlag",
+    "contributorPersentTypeCd",
+    "contributorNameOrganization",
+    "contributorNameLast",
+    "contributorNameSuffixCd",
+    "contributorNameFirst",
+    "contributorNamePrefixCd",
+    "contributorNameShort",
+    "contributorStreetCity",
+    "contributorStreetStateCd",
+    "contributorStreetCountyCd",
+    "contributorStreetCountryCd",
+    "contributorStreetPostalCode",
+    "contributorStreetRegion",
+    "contributorEmployer",
+    "contributorOccupation",
+    "contributorJobTitle",
+    "contributorPacFein",
+    "contributorOosPacFlag",
+    "contributorLawFirmName",
+    "contributorSpouseLawFirmName",
+    "contributorParent1LawFirmName",
+    "contributorParent2LawFirmName",
+)
+
+_EXPN_COLS = (
+    "recordType",
+    "formTypeCd",
+    "schedFormTypeCd",
+    "reportInfoIdent",
+    "receivedDt",
+    "infoOnlyFlag",
+    "filerIdent",
+    "filerTypeCd",
+    "filerName",
+    "expendInfoId",
+    "expendDt",
+    "expendAmount",
+    "expendDescr",
+    "expendCatCd",
+    "expendCatDescr",
+    "itemizeFlag",
+    "travelFlag",
+    "politicalExpendCd",
+    "reimburseIntendedFlag",
+    "srcCorpContribFlag",
+    "capitalLivingexpFlag",
+    "payeePersentTypeCd",
+    "payeeNameOrganization",
+    "payeeNameLast",
+    "payeeNameSuffixCd",
+    "payeeNameFirst",
+    "payeeNamePrefixCd",
+    "payeeNameShort",
+    "payeeStreetAddr1",
+    "payeeStreetAddr2",
+    "payeeStreetCity",
+    "payeeStreetStateCd",
+    "payeeStreetCountyCd",
+    "payeeStreetCountryCd",
+    "payeeStreetPostalCode",
+    "payeeStreetRegion",
+    "creditCardIssuer",
+    "repaymentDt",
+)
+
+
+def _read(files: list[Path]) -> pl.DataFrame | None:
+    frames = [pl.read_parquet(p) for p in files]
+    if not frames:
+        return None
+    return frames[0] if len(frames) == 1 else pl.concat(frames, how="diagonal_relaxed")
+
+
+def _ensure_cols(df: pl.DataFrame, names: Iterable[str]) -> pl.DataFrame:
+    """Add any referenced source column missing from *df* as a null Utf8 column."""
+    missing = [pl.lit(None, dtype=pl.Utf8).alias(n) for n in names if n not in df.columns]
+    return df.with_columns(missing) if missing else df
+
+
+def _transaction_date_expr(date_col: str) -> pl.Expr:
+    """builder_date on *date_col*, falling back to receivedDt when null.
+
+    Mirrors builders.build_transaction lines 97-103:
+        transaction.transaction_date = self._parse_date(self._get_field_value(...))
+        if transaction.transaction_date is None:
+            transaction.transaction_date = self._parse_date(raw_data.get("receivedDt"))
+    """
+    primary = common.builder_date(date_col)
+    fallback = common.builder_date("receivedDt")
+    return primary.fill_null(fallback)
+
+
+def _filed_date_expr() -> pl.Expr:
+    """Mirror the ORM's filed_date resolution for RCPT/EXPN.
+
+    The field library maps BOTH ``filedDt`` and ``receivedDt`` to the unified
+    field ``filed_date``.  build_transaction calls::
+
+        self._get_field_value(raw_data, "filed_date")
+
+    which iterates state field mappings in definition order and returns the
+    FIRST matching key found in raw_data.  For RCPT/EXPN parquet the
+    ``filedDt`` column does not exist (it is a CVR1-only column); the only
+    source column present is ``receivedDt``.  So in practice the ORM always
+    resolves filed_date = builder_date(receivedDt) for these record types.
+    """
+    return common.builder_date("receivedDt")
+
+
+def _build_transactions(
+    df: pl.DataFrame,
+    *,
+    id_col: str,
+    amount_col: str,
+    date_col: str,
+    descr_col: str,
+    transaction_type: str,
+    orig_cols: list[str],
+    ctx: FamilyContext,
+) -> pl.DataFrame:
+    """Shared transform for RCPT and EXPN rows into unified_transactions shape."""
+    return df.with_columns(
+        [
+            pl.lit(ctx.state_id).alias("state_id"),
+            common.clean_str(id_col).alias("transaction_id"),
+            common.builder_amount(amount_col).alias("amount"),
+            _transaction_date_expr(date_col).alias("transaction_date"),
+            common.clean_str(descr_col).alias("description"),
+            pl.lit(transaction_type).alias("transaction_type"),
+            # committee_id: filerIdent (_finalize_transaction_for_persist)
+            common.clean_str("filerIdent").alias("committee_id"),
+            # report_ident: reportInfoIdent (build_transaction + _finalize)
+            common.clean_str("reportInfoIdent").alias("report_ident"),
+            _filed_date_expr().alias("filed_date"),
+            pl.lit(False).alias("amended"),
+            pl.lit(None, dtype=pl.Utf8).alias("file_origin_id"),
+            common.raw_json_expr(orig_cols, alias="raw_data"),
+        ]
+    ).select(
+        "state_id",
+        "transaction_id",
+        "amount",
+        "transaction_date",
+        "description",
+        "transaction_type",
+        "committee_id",
+        "report_ident",
+        "filed_date",
+        "amended",
+        "file_origin_id",
+        "raw_data",
+    )
+
+
+class FlatTxnsWorker:
+    record_types = frozenset({"RCPT", "EXPN"})
+    priority = 10  # mirrors _FILE_PRIORITY["RCPT"]
+
+    def run(self, files_by_type: dict[str, list[Path]], ctx: FamilyContext) -> dict[str, int]:
+        loaded = 0
+
+        rcpt = _read(files_by_type.get("RCPT", []))
+        if rcpt is not None:
+            loaded += self._load_rcpt(rcpt, ctx)
+
+        expn = _read(files_by_type.get("EXPN", []))
+        if expn is not None:
+            loaded += self._load_expn(expn, ctx)
+
+        return {"loaded": loaded}
+
+    def _load_rcpt(self, df: pl.DataFrame, ctx: FamilyContext) -> int:
+        orig_cols = df.columns
+        df = _ensure_cols(df, _RCPT_COLS)
+        out = _build_transactions(
+            df,
+            id_col="contributionInfoId",
+            amount_col="contributionAmount",
+            date_col="contributionDt",
+            descr_col="contributionDescr",
+            transaction_type="CONTRIBUTION",
+            orig_cols=orig_cols,
+            ctx=ctx,
+        )
+        return common.write_frame(
+            ctx.session, UnifiedTransaction, out, conflict_cols=None
+        )
+
+    def _load_expn(self, df: pl.DataFrame, ctx: FamilyContext) -> int:
+        orig_cols = df.columns
+        df = _ensure_cols(df, _EXPN_COLS)
+        out = _build_transactions(
+            df,
+            id_col="expendInfoId",
+            amount_col="expendAmount",
+            date_col="expendDt",
+            descr_col="expendDescr",
+            transaction_type="EXPENDITURE",
+            orig_cols=orig_cols,
+            ctx=ctx,
+        )
+        return common.write_frame(
+            ctx.session, UnifiedTransaction, out, conflict_cols=None
+        )
+
+
+register(FlatTxnsWorker())

--- a/tests/ingest_equivalence/test_flat_txns_family.py
+++ b/tests/ingest_equivalence/test_flat_txns_family.py
@@ -1,0 +1,149 @@
+"""Gate: the vectorized flat_txns family == the ORM loader for unified_transactions.
+
+Loads ONLY the RCPT (contribs_golden) and EXPN (expend_golden) fixtures via both
+the ORM loader and ``run_vectorized`` (flat_txns family registered), then asserts
+that ``diff_snapshots`` restricted to ``unified_transactions`` is empty.
+
+Foreign-key parent tables (unified_committees, unified_reports, etc.) are NOT
+populated on the vectorized side — ``enforce_fk=False`` is used, mirroring the
+reports-family gate.  The surrogate FK columns (committee_id → int, etc.) are
+dropped by the harness anyway; only the natural-key committee_id string is kept.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.ingest_equivalence import diff_snapshots, snapshot_unified
+from app.core.ingest_vectorized import run_vectorized
+from tests.ingest_equivalence.test_harness import FIXTURES, _make_engine
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FLAT_TXN_RECORD_TYPES = frozenset({"RCPT", "EXPN"})
+_FLAT_TXN_FILENAMES = frozenset({"contribs_golden.parquet", "expend_golden.parquet"})
+
+
+def _load_golden_rcpt_expn(engine) -> None:
+    """ORM-load ONLY the RCPT and EXPN golden fixtures.
+
+    Mirrors ``test_harness._load_golden`` but filters discovered files to just
+    contribs_golden (RCPT) and expend_golden (EXPN).  FK parents (committees,
+    reports) are NOT seeded — matching the vectorized side where enforce_fk=False.
+    """
+    from sqlmodel import Session
+
+    from app.core.load_cache import BuilderCache
+    from scripts.loaders import production_loader as P
+    from scripts.loaders.file_discovery import discover_state_files
+    from scripts.loaders.loader_config import LoaderConfig
+
+    session = Session(engine, expire_on_commit=False)
+    try:
+        P._ensure_committee_types(session)
+        state = P._ensure_state(session, "texas")
+        cache = BuilderCache()
+        cfg = LoaderConfig(batch_size=1000, commit_frequency=1000)
+        discovered = sorted(
+            (
+                (item.path, item.record_type)
+                for item in discover_state_files("texas", base_dir=FIXTURES)
+                if item.record_type in _FLAT_TXN_RECORD_TYPES
+            ),
+            key=lambda p_rt: (P._FILE_PRIORITY.get(p_rt[1] or "", 50), str(p_rt[0])),
+        )
+        assert discovered, "no RCPT/EXPN golden fixtures discovered"
+        for path, rtype in discovered:
+            _n, _rej, cache = P._load_file(
+                path,
+                rtype,
+                cfg,
+                state="texas",
+                state_id=state.id,
+                state_code=state.code,
+                session=session,
+                cache=cache,
+                max_remaining=None,
+            )
+        session.commit()
+    finally:
+        session.close()
+
+
+def _flat_txns_only(snap: dict) -> dict:
+    """Restrict a snapshot to unified_transactions only."""
+    return {"unified_transactions": snap.get("unified_transactions", [])}
+
+
+# ---------------------------------------------------------------------------
+# Vectorized-only fixture directory containing ONLY RCPT / EXPN files
+# ---------------------------------------------------------------------------
+
+def _make_rcpt_expn_fixtures_dir(tmp_path: Path) -> Path:
+    """Symlink (or copy) only contribs/expend golden parquets into a sub-dir.
+
+    run_vectorized runs file_discovery on the fixtures_dir, which would also
+    pick up CVR1/FILER/etc. files.  We point discovery at a directory containing
+    ONLY the two files so the flat_txns worker sees exactly what we ORM-load.
+    """
+    import shutil
+
+    sub = tmp_path / "flat_only"
+    sub.mkdir()
+    for name in _FLAT_TXN_FILENAMES:
+        src = FIXTURES / name
+        shutil.copy2(src, sub / name)
+    return sub
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_flat_txns_family_matches_orm(tmp_path: Path):
+    """unified_transactions from RCPT+EXPN must be row-for-row equal (ORM vs vectorized)."""
+    # ORM side: load ONLY RCPT+EXPN into its own DB (FK=ON is fine; committees
+    # aren't added so committee_id FK is a dangling reference, but SQLite won't
+    # enforce it without explicit PRAGMA foreign_keys=ON).
+    orm_engine = _make_engine(tmp_path / "orm.db", enforce_fk=False)
+    _load_golden_rcpt_expn(orm_engine)
+
+    # Vectorized side: run only flat_txns worker over the RCPT/EXPN files.
+    flat_fixtures = _make_rcpt_expn_fixtures_dir(tmp_path)
+    vec_engine = _make_engine(tmp_path / "vec.db", enforce_fk=False)
+    run_vectorized(vec_engine, flat_fixtures)
+
+    orm = _flat_txns_only(snapshot_unified(orm_engine))
+    vec = _flat_txns_only(snapshot_unified(vec_engine))
+
+    assert orm["unified_transactions"], "ORM produced no transactions — fixture/loader problem"
+    assert vec["unified_transactions"], "vectorized produced no transactions — family not running"
+
+    diffs = diff_snapshots(orm, vec)
+    assert diffs == [], (
+        "unified_transactions diverge from ORM:\n" + "\n".join(diffs)
+    )
+
+
+def test_flat_txns_contribution_count(tmp_path: Path):
+    """RCPT fixture must produce at least one CONTRIBUTION transaction."""
+    flat_fixtures = _make_rcpt_expn_fixtures_dir(tmp_path)
+    vec_engine = _make_engine(tmp_path / "vec.db", enforce_fk=False)
+    run_vectorized(vec_engine, flat_fixtures)
+    snap = snapshot_unified(vec_engine)
+    txns = snap.get("unified_transactions", [])
+    contributions = [t for t in txns if t.get("transaction_type") == "CONTRIBUTION"]
+    assert contributions, "expected CONTRIBUTION transactions from RCPT fixture"
+
+
+def test_flat_txns_expenditure_count(tmp_path: Path):
+    """EXPN fixture must produce at least one EXPENDITURE transaction."""
+    flat_fixtures = _make_rcpt_expn_fixtures_dir(tmp_path)
+    vec_engine = _make_engine(tmp_path / "vec.db", enforce_fk=False)
+    run_vectorized(vec_engine, flat_fixtures)
+    snap = snapshot_unified(vec_engine)
+    txns = snap.get("unified_transactions", [])
+    expenditures = [t for t in txns if t.get("transaction_type") == "EXPENDITURE"]
+    assert expenditures, "expected EXPENDITURE transactions from EXPN fixture"


### PR DESCRIPTION
Second Phase-B family of the vectorized ingest engine — the **transactions** slice of flat_txns, gated row-for-row equal to the ORM.

## What's here
- **`app/core/ingest_vectorized/families/flat_txns.py`** — `FlatTxnsWorker` (priority 10) reproduces `build_transaction` + the loader's `_finalize_transaction_for_persist` columnar (pure Polars, **no `map_elements`**) for RCPT→CONTRIBUTION and EXPN→EXPENDITURE → `unified_transactions`: `builder_amount`/`builder_date` (builders dialect) with `receivedDt` date fallback, `transaction_id`/`description` assigned **unstripped** (matching `_get_field_value`), `transaction_type` stored as the enum name, `committee_id`=filerIdent, `report_ident`=reportInfoIdent, `raw_data` provenance, plain insert (no natural key, matching the ORM).
- **Gate** (`tests/ingest_equivalence/test_flat_txns_family.py`): load only the RCPT+EXPN fixtures (650 rows) via the ORM loader **and** `run_vectorized`, assert `diff_snapshots` restricted to `unified_transactions` **== []**.

## Evidence
- **27** `tests/ingest_equivalence` tests pass; ruff clean; **no `map_elements`/`.apply`**; code-reviewer **APPROVED** (M1 unstripped-id/description fix + L1 load-log applied).

## Deferred (staged — next slice)
The **dim layer** (`unified_persons`/`entities`/`addresses`/`committees`) + `unified_contributions`/`unified_expenditures` + `unified_transaction_persons`. The gate is clean at the `unified_transactions` boundary; the dim-dedup builder (using the merged dim-normalization primitives #36) is the next gated unit.

Builds on #36 (merged). Diff vs `main` is the flat_txns family + its gate test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vectorized ingestion for flat transaction records, transforming contribution and expenditure data into a unified transaction format with standardized fields including transaction IDs, amounts, descriptions, types, and dates.

* **Tests**
  * Added equivalence tests validating the new ingestion path against existing behavior and verifying correct transaction type classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->