### PR TITLE
Harness FK→natural-key resolution (linkage infra for batch fan-out)

### DIFF
--- a/app/core/ingest_equivalence.py
+++ b/app/core/ingest_equivalence.py
@@ -99,12 +99,96 @@ def _sort_key(row: dict[str, Any]) -> tuple[str, ...]:
     return tuple("" if v is None else str(v) for _k, v in sorted(row.items()))
 
 
-def snapshot_unified(engine: Engine) -> dict[str, list[dict[str, Any]]]:
+def _intra_fk_parents(inspector: Any, table: str, targets: set[str]) -> dict[str, str]:
+    """{column: parent_table} for surrogate FKs (-> parent.id) whose parent is itself
+    a snapshot target (unified_/canonical_). These get RESOLVED to the parent's natural
+    key in resolve_fks mode (instead of dropped). FKs to non-target tables
+    (file_origins, states) stay dropped — they are provenance, not logical linkage."""
+    out: dict[str, str] = {}
+    for fk in inspector.get_foreign_keys(table):
+        if fk.get("referred_columns") == ["id"] and fk.get("referred_table") in targets:
+            for cc in fk.get("constrained_columns", []):
+                out[cc] = fk["referred_table"]
+    return out
+
+
+def _snapshot_resolved(engine: Engine) -> dict[str, list[dict[str, Any]]]:
+    """snapshot_unified with surrogate FKs RESOLVED to parent natural keys.
+
+    Lets the gate verify relational LINKAGE (e.g. a contribution's contributor entity)
+    instead of dropping surrogate ids. Recursive (entity -> person -> address), memoized,
+    cycle-guarded. Only intra-target FKs are resolved; provenance FKs and volatile cols
+    are dropped exactly as in the default snapshot.
+    """
+    inspector = inspect(engine)
+    targets = set(_target_tables(inspector))
+    md = MetaData()
+    raw: dict[str, dict[Any, dict[str, Any]]] = {}
+    intra: dict[str, dict[str, str]] = {}
+    drop_cols: dict[str, set[str]] = {}
+    cols_by_table: dict[str, list[str]] = {}
+    for table in targets:
+        tbl = Table(table, md, autoload_with=engine)
+        cols = [c.name for c in tbl.columns]
+        cols_by_table[table] = cols
+        intra[table] = _intra_fk_parents(inspector, table, targets)
+        # Drop: volatile + surrogate FKs to NON-target parents (provenance). Intra-target
+        # FK columns are kept here and resolved; the 'id' PK is dropped from output.
+        ext_fk = _surrogate_fk_columns(inspector, table) - set(intra[table])
+        drop_cols[table] = set(VOLATILE_COLUMNS) | ext_fk
+        with engine.connect() as conn:
+            raw[table] = {m["id"]: dict(m) for m in conn.execute(select(tbl)).mappings().all()}
+
+    memo: dict[tuple[str, Any], Any] = {}
+
+    def resolve(table: str, fk_id: Any, stack: frozenset) -> Any:
+        if fk_id is None:
+            return None
+        key = (table, fk_id)
+        if key in memo:
+            return memo[key]
+        if key in stack or table not in raw or fk_id not in raw[table]:
+            return f"<unresolved:{table}:{fk_id}>"
+        nat = natural(table, raw[table][fk_id], stack | {key})
+        memo[key] = nat
+        return nat
+
+    def natural(table: str, row: dict[str, Any], stack: frozenset) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for col in cols_by_table[table]:
+            if col == "id" or col in drop_cols[table]:
+                continue
+            if col in intra[table]:
+                out[col] = resolve(intra[table][col], row.get(col), stack)
+            elif col in JSON_COLUMNS:
+                out[col] = _canonicalize_json(row.get(col))
+            else:
+                v = row.get(col)
+                out[col] = None if v is None else str(v)
+        return out
+
+    snapshot: dict[str, list[dict[str, Any]]] = {}
+    for table in targets:
+        rows = [natural(table, r, frozenset()) for r in raw[table].values()]
+        rows.sort(key=_sort_key)
+        snapshot[table] = rows
+    return snapshot
+
+
+def snapshot_unified(
+    engine: Engine, *, resolve_fks: bool = False
+) -> dict[str, list[dict[str, Any]]]:
     """Return {table: [normalized row dicts]} for every unified/canonical table.
 
     Volatile + surrogate-FK columns are dropped; rows are deterministically sorted.
     Built with SQLAlchemy core ``select`` over reflected tables (no string SQL).
+
+    ``resolve_fks=True`` resolves intra-target surrogate FKs to the parent's natural key
+    (recursively) so the gate can verify relational linkage — opt-in, since it is
+    strictly stricter than the default drop-surrogate-FK behavior.
     """
+    if resolve_fks:
+        return _snapshot_resolved(engine)
     inspector = inspect(engine)
     snapshot: dict[str, list[dict[str, Any]]] = {}
     md = MetaData()

--- a/tests/ingest_equivalence/test_fk_resolution.py
+++ b/tests/ingest_equivalence/test_fk_resolution.py
@@ -1,0 +1,75 @@
+"""Tests for snapshot_unified(resolve_fks=True): the harness FK->natural-key resolution
+that lets the gate verify relational linkage (the linkage-infra enabling detail/junction
++ detail_children/cand families to be gated on their entity/person links).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import create_engine, insert
+from sqlmodel import Session, SQLModel
+
+from app.core import models  # noqa: F401 — register tables
+from app.core.enums import PersonType
+from app.core.ingest_equivalence import diff_snapshots, snapshot_unified
+from app.core.models import UnifiedAddress, UnifiedPerson
+
+
+def _engine(db_path: Path):
+    engine = create_engine(f"sqlite:///{db_path}")
+    tables = [t for t in SQLModel.metadata.tables.values() if t.schema is None]
+    SQLModel.metadata.create_all(engine, tables=list(tables))
+    return engine
+
+
+def _seed(engine, *, addr_id: int, person_id: int, street: str, last: str) -> None:
+    with Session(engine) as s:
+        s.execute(
+            insert(UnifiedAddress.__table__),
+            [{"id": addr_id, "uuid": f"a{addr_id}", "street_1": street, "city": "X",
+              "state": "TX", "zip_code": "1"}],
+        )
+        s.execute(
+            insert(UnifiedPerson.__table__),
+            [{"id": person_id, "uuid": f"p{person_id}", "first_name": "J", "last_name": last,
+              "person_type": PersonType.INDIVIDUAL, "address_id": addr_id}],
+        )
+        s.commit()
+
+
+def test_resolution_equal_despite_different_surrogate_ids(tmp_path: Path):
+    """Same logical data with different surrogate ids compares equal under resolution."""
+    a = _engine(tmp_path / "a.db")
+    _seed(a, addr_id=1, person_id=1, street="100 A St", last="DOE")
+    b = _engine(tmp_path / "b.db")
+    _seed(b, addr_id=77, person_id=42, street="100 A St", last="DOE")
+
+    assert diff_snapshots(
+        snapshot_unified(a, resolve_fks=True), snapshot_unified(b, resolve_fks=True)
+    ) == []
+
+
+def test_resolution_detects_linkage_difference_that_drop_fk_misses(tmp_path: Path):
+    """A person linked to a DIFFERENT address: drop-FK can't see it; resolution does."""
+    a = _engine(tmp_path / "a.db")
+    _seed(a, addr_id=1, person_id=1, street="100 A St", last="DOE")
+    c = _engine(tmp_path / "c.db")
+    _seed(c, addr_id=1, person_id=1, street="999 DIFFERENT Blvd", last="DOE")
+
+    pa = {"unified_persons": snapshot_unified(a)["unified_persons"]}
+    pc = {"unified_persons": snapshot_unified(c)["unified_persons"]}
+    # Default (surrogate FK dropped): the person rows look identical — the address
+    # divergence is invisible. This is the limitation resolution closes.
+    assert diff_snapshots(pa, pc) == []
+
+    ra = {"unified_persons": snapshot_unified(a, resolve_fks=True)["unified_persons"]}
+    rc = {"unified_persons": snapshot_unified(c, resolve_fks=True)["unified_persons"]}
+    assert diff_snapshots(ra, rc) != []
+
+
+def test_resolution_default_off_is_backward_compatible(tmp_path: Path):
+    """Default snapshot still drops surrogate FKs (address_id absent from person rows)."""
+    a = _engine(tmp_path / "a.db")
+    _seed(a, addr_id=1, person_id=1, street="100 A St", last="DOE")
+    persons = snapshot_unified(a)["unified_persons"]
+    assert persons and "address_id" not in persons[0]


### PR DESCRIPTION
The **last sequential piece** before the vectorized families fan out in parallel: the equivalence gate can now verify relational **linkage** (a contribution's contributor entity, a transaction_person's person) instead of dropping surrogate FKs.

## What's here
- **`app/core/ingest_equivalence.py`** — `snapshot_unified(engine, *, resolve_fks=False)`. With `resolve_fks=True`, intra-target surrogate FKs (`FK → unified_/canonical_.id`) are **resolved recursively to the parent's natural key** (memoized, cycle-guarded); provenance FKs (`file_origins`, `states`) and volatile columns stay dropped; natural-key FKs (`committee_id → filer_id`) pass through as-is. **Opt-in** — the default is byte-for-byte unchanged, so already-merged gates aren't retroactively tightened.
- **`tests/ingest_equivalence/test_fk_resolution.py`** — proves resolution (a) keeps same-linkage data equal across different surrogate ids, (b) **detects** a linkage difference the default drop-FK behavior misses, (c) default-off is backward-compatible.

## Why this matters
The deferred detail/junction tables (`contributions`/`expenditures`/`transaction_persons`) and the upcoming `detail_children`/`cand` families all link to persons/entities. They can now be gated **on that linkage** (real id-joins + `resolve_fks=True`) rather than dropped surrogate FKs. This is the shared capability they all reuse — so once it lands, those families are independent leaves that fan out in parallel.

## Evidence
- 31 `tests/ingest_equivalence` tests pass (28 + 3); ruff clean; code-reviewer **APPROVED**.

Builds on #38 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional foreign key resolution mode to snapshot comparison, enabling more accurate detection of data linkage differences across systems with different surrogate ID schemes.

* **Tests**
  * Added comprehensive test coverage for foreign key resolution behavior, verifying backward compatibility with existing snapshot comparison workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->