### PR TITLE
Vectorized flat_txns detail/junction (contributions/expenditures/transaction_persons), gated on resolve_fks=True

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,69 +1,35 @@
-# TASK — Address 25%-subset test findings (2026-06-14)
+# TASK — Vectorized flat_txns detail/junction family (RCPT/EXPN)
+
+Plan: docs/design/vectorized-ingest-plan.md · Gate: app/core/ingest_equivalence.py
 
 ## Goal
-Fix the four findings surfaced by the 2026-06-14 subset end-to-end test, in
-priority order. Each fix must be reflection/idempotency-safe and run identically
-on sqlite (tests) and postgres (real).
+Extend the vectorized ingest engine with the flat_txns detail/junction family:
+RCPT → `unified_contributions`, EXPN → `unified_expenditures`, and the
+`unified_transaction_persons` junction, with entity/person FK linkage filled by
+real surrogate-id joins against the already-written dim + transaction tables.
 
-## Findings & acceptance criteria
-
-### #1 Schema drift / no migration  (HIGH)
-- **Problem:** wave-2 (`unified_reports.committee_name_at_filing`,
-  `treasurer_name_at_filing`) and wave-3 (`canonical_entity.employer`) columns
-  exist only via a fresh `create_all`; existing DBs break on insert. Unified layer
-  has no additive-column shim; resolve's `_ADDITIVE_COLUMNS` omits `employer`.
-- **Fix:** add a unified additive-column shim (mirror
-  `app/resolve/run.py::_ensure_additive_columns`) invoked from
-  `UnifiedDatabaseManager.bootstrap()`; add `canonical_entity.employer` to resolve
-  `_ADDITIVE_COLUMNS`.
-- **Files:** `app/core/unified_database.py`, `app/resolve/run.py`.
-- **Done when:** on a DB pre-created WITHOUT the new columns, bootstrap/ensure adds
-  them (idempotent re-run = no-op); report + canonical inserts succeed. New tests.
-
-### #3 CAND duplicate rejects  (MED) — DONE (enrichment linkage)
-- **Root cause:** CAND records are candidate↔expenditure *linkages*, not standalone
-  transactions. `expendInfoId` is the EXPENDITURE id; cand has 62K internal dup
-  expendInfoIds and overlaps the expend files, so loading as EXPENDITURE double-counts
-  and collides on the dedup index.
-- **Decision (user):** proper enrichment linkage.
-- **Implemented:** CAND removed from `TRANSACTION_RECORD_TYPES`; new
-  `ENRICHMENT_RECORD_TYPES` + `_persist_cand_link` in `scripts/loaders/production_loader.py`
-  resolves the candidate person and attaches `UnifiedTransactionPerson(role=CANDIDATE)`
-  to the matching expenditure (idempotent on the natural key; unlinked when the
-  expenditure isn't in the load).
-- **Evidence (subset_load2):** rejected=0 (was 556), ingest_errors=0, 565 candidate
-  links (328 distinct candidates), no duplicate EXPENDITURE rows. 6 new unit tests.
-
-### #2 Bulk loader throughput  (LARGE) — DONE (bounded fix + scope note)
-- **Problem:** per-row ORM persist ~111 txn/s; full load infeasible.
-- **Implemented:** raised the production preset to batch_size=2000/commit_frequency=2000
-  (was 500/20 — one fsync per 20 rows). Measured 74→111 rows/s going cf 20→5000 on
-  the subset run; this captures the I/O batching win.
-- **Scope note (deferred):** the ~111 rows/s ceiling is CPU-bound per-row ORM object
-  construction (UnifiedTransaction + persons + detail + entity/address dedup). Only a
-  COPY-based bulk path removes it (a real rewrite: flatten the object graph, manage
-  ids, type-specific COPY). Documented in the loader_config comment. NOT attempted
-  here.
-- **Files:** `scripts/loaders/loader_config.py`.
-
-### #4 address_occupancy empty  (MED) — DONE
-- **Root cause:** `canonical_address_id` was only populated by a separate
-  `--pass-type address` invocation; the default entity run left it NULL, so the
-  occupancy view was always empty.
-- **Implemented:** appended an address-link stage (stage 8) to the entity pass
-  (`_run_address_link_stage` in `app/resolve/cli.py`) that builds canonical_address
-  + backfills the FK. Returns non-`_COUNTER_COLS` keys so it does NOT clobber
-  survivorship's `canonical_out` in match_run.
-- **Evidence (run_id=11):** single entity run → canonical_address 22,498,
-  canonical_entity.canonical_address_id set on 27,260; match_run.canonical_out=68,073
-  (entity count, not addr); after publish, address_occupancy = 27,260 rows. New tests.
-
-## Checks to run (evidence required before done)
-- `uv run ruff check` clean on changed files.
-- `uv run pytest` targeted suites green (core loader, resolve run, survivorship).
-- Re-run the subset ingest + resolve to confirm #1/#3/#4 behave on real data.
-- task-critic PASS.
+## Files in scope
+- `app/core/ingest_vectorized/families/flat_txns_detail.py` (NEW)
+- `app/core/ingest_vectorized/families/__init__.py` (import new module)
+- `tests/ingest_equivalence/test_flat_txns_detail_family.py` (NEW)
 
 ## Behavior to preserve
-- sqlite test path unchanged where possible; all DDL reflection-guarded + idempotent.
-- No change to existing column semantics; additive only.
+- Pure Polars column expressions; NO `map_elements` / `.apply()`.
+- No f-string / concatenated SQL — SQLAlchemy core parameterized `select` only.
+- Mirror ORM builder/processor semantics EXACTLY:
+  - Contribution created only when contributor entity AND recipient (committee)
+    entity both exist; expenditure only when payer (committee) AND payee entity
+    both exist.
+  - transaction_persons: one row per non-null participant, RECIPIENT excluded
+    (RCPT→CONTRIBUTOR, EXPN→PAYEE); entity_id = person.entity.id.
+  - contribution_type / expenditure_type unmapped → None; is_anonymous default.
+  - amount/date/description copied from the parent transaction row.
+- Priority runs AFTER flat_txns_dims (9) and flat_txns (10) → priority 11.
+
+## Checks to run (evidence for done)
+1. `uv run pytest tests/ingest_equivalence -q` → all green (existing + new test).
+2. New test: `diff_snapshots` over
+   (`unified_contributions`,`unified_expenditures`,`unified_transaction_persons`)
+   with `resolve_fks=True` == `[]`; both sides non-empty.
+3. `grep -rnE "map_elements|\.apply\(" app/core/ingest_vectorized/families/flat_txns_detail.py` → empty.
+4. `uv run ruff check app/core/ingest_vectorized tests/ingest_equivalence` → clean.

--- a/app/core/ingest_equivalence.py
+++ b/app/core/ingest_equivalence.py
@@ -136,8 +136,17 @@ def _snapshot_resolved(engine: Engine) -> dict[str, list[dict[str, Any]]]:
         # FK columns are kept here and resolved; the 'id' PK is dropped from output.
         ext_fk = _surrogate_fk_columns(inspector, table) - set(intra[table])
         drop_cols[table] = set(VOLATILE_COLUMNS) | ext_fk
+        # Key rows by the table's own primary key.  Most unified/canonical tables use a
+        # surrogate ``id``, but some (e.g. ``unified_committees``) use a natural PK
+        # (``filer_id``).  Intra-target FK resolution only ever targets ``id`` parents
+        # (see ``_intra_fk_parents``), so non-``id``-PK tables are never resolution
+        # targets — they only need a stable row key here to be snapshotted at all.
+        pk_cols = [c.name for c in tbl.primary_key.columns] or ["id"]
+        pk_col = "id" if "id" in cols else pk_cols[0]
         with engine.connect() as conn:
-            raw[table] = {m["id"]: dict(m) for m in conn.execute(select(tbl)).mappings().all()}
+            raw[table] = {
+                m[pk_col]: dict(m) for m in conn.execute(select(tbl)).mappings().all()
+            }
 
     memo: dict[tuple[str, Any], Any] = {}
 

--- a/app/core/ingest_vectorized/families/__init__.py
+++ b/app/core/ingest_vectorized/families/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 # Family modules are imported here as they land so the dispatcher registers them.
 from app.core.ingest_vectorized.families import (  # noqa: F401
     flat_txns,
+    flat_txns_detail,
     flat_txns_dims,
     reports,
 )

--- a/app/core/ingest_vectorized/families/flat_txns_detail.py
+++ b/app/core/ingest_vectorized/families/flat_txns_detail.py
@@ -1,0 +1,796 @@
+"""Vectorized flat-transactions DETAIL/JUNCTION family for RCPT / EXPN.
+
+Runs AFTER ``flat_txns_dims`` (priority 9, writes persons/entities/addresses/
+committees) and ``flat_txns`` (priority 10, writes ``unified_transactions``), so
+every surrogate id this family references already exists. Priority 11.
+
+Produces, with REAL surrogate-id linkage (id-maps read back by natural key):
+  RCPT -> ``unified_contributions``      (contributor_entity_id, recipient_entity_id)
+  EXPN -> ``unified_expenditures``       (payer_entity_id, payee_entity_id)
+  both -> ``unified_transaction_persons``(transaction_id, person_id, entity_id, role)
+
+Mirrors ``app/core/processor.py``::
+  * ``RECORD_TYPE_ROLE_MAP``: RCPT -> {CONTRIBUTOR: "contributor"},
+    EXPN -> {PAYEE: "payee"}.
+  * ``_build_contribution_detail``: created ONLY when contributor_entity AND
+    recipient_entity (the committee entity) both exist.
+  * ``_build_expenditure_detail``: created ONLY when payer_entity (committee) AND
+    payee_entity both exist.
+  * ``_attach_transaction_persons``: one junction row per built participant, with
+    RECIPIENT excluded (RCPT only builds CONTRIBUTOR, EXPN only builds PAYEE, so the
+    exclusion is a no-op here but kept explicit), ``entity_id = person.entity.id``.
+  * ``contribution_type`` / ``expenditure_type`` are unmapped for Texas RCPT/EXPN
+    (``_get_field_value`` -> None); ``is_anonymous`` keeps its model default (False).
+  * amount / date / description are copied from the parent transaction row
+    (``transaction.amount`` / ``.transaction_date`` / ``.description``), so they are
+    re-derived here from the same source columns the flat_txns family uses.
+
+Linkage (id-joins, NEVER surrogate guesses):
+  * Transaction id  <- (state_id, transaction_type, transaction_id) natural key.
+  * Person id       <- (lower(first), lower(last), lower(org)) within the state.
+  * Person-entity id<- (entity_type, normalized_name) within the state.
+  * Committee-entity<- (COMMITTEE, normalize_entity_name(committee name)) within state.
+All id-maps are read via SQLAlchemy core ``select`` (parameterized) over the already
+-written tables, then attached with Polars joins. Pure column expressions only —
+no per-row Python UDF (no element-wise map, no row apply).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import polars as pl
+from sqlalchemy import select
+
+from app.core.ingest_vectorized import common
+from app.core.ingest_vectorized.registry import FamilyContext, register
+from app.core.models import (
+    UnifiedContribution,
+    UnifiedEntity,
+    UnifiedExpenditure,
+    UnifiedPerson,
+    UnifiedTransaction,
+    UnifiedTransactionPerson,
+)
+from app.logger import Logger
+
+_logger = Logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Source column whitelists (kept in lockstep with flat_txns / flat_txns_dims).
+# ---------------------------------------------------------------------------
+
+_RCPT_COLS = (
+    "recordType", "formTypeCd", "schedFormTypeCd", "reportInfoIdent",
+    "receivedDt", "infoOnlyFlag", "filerIdent", "filerTypeCd", "filerName",
+    "contributionInfoId", "contributionDt", "contributionAmount", "contributionDescr",
+    "itemizeFlag", "travelFlag",
+    "contributorPersentTypeCd", "contributorNameOrganization",
+    "contributorNameLast", "contributorNameSuffixCd", "contributorNameFirst",
+    "contributorNamePrefixCd", "contributorNameShort",
+    "contributorStreetCity", "contributorStreetStateCd", "contributorStreetCountyCd",
+    "contributorStreetCountryCd", "contributorStreetPostalCode", "contributorStreetRegion",
+    "contributorEmployer", "contributorOccupation", "contributorJobTitle",
+    "contributorPacFein", "contributorOosPacFlag",
+    "contributorLawFirmName", "contributorSpouseLawFirmName",
+    "contributorParent1LawFirmName", "contributorParent2LawFirmName",
+)
+
+_EXPN_COLS = (
+    "recordType", "formTypeCd", "schedFormTypeCd", "reportInfoIdent",
+    "receivedDt", "infoOnlyFlag", "filerIdent", "filerTypeCd", "filerName",
+    "expendInfoId", "expendDt", "expendAmount", "expendDescr",
+    "expendCatCd", "expendCatDescr", "itemizeFlag", "travelFlag",
+    "politicalExpendCd", "reimburseIntendedFlag", "srcCorpContribFlag", "capitalLivingexpFlag",
+    "payeePersentTypeCd", "payeeNameOrganization",
+    "payeeNameLast", "payeeNameSuffixCd", "payeeNameFirst",
+    "payeeNamePrefixCd", "payeeNameShort",
+    "payeeStreetAddr1", "payeeStreetAddr2",
+    "payeeStreetCity", "payeeStreetStateCd", "payeeStreetCountyCd",
+    "payeeStreetCountryCd", "payeeStreetPostalCode", "payeeStreetRegion",
+    "creditCardIssuer", "repaymentDt",
+)
+
+# Placeholder last names that force PersonType.UNKNOWN (mirrors build_person /
+# constants.PLACEHOLDER_NAMES, applied case-insensitively on the stripped last name).
+_PLACEHOLDER_NAMES_UPPER = frozenset({
+    "NON-ITEMIZED CONTRIBUTOR", "NON-ITEMIZED", "UNKNOWN", "ANONYMOUS",
+})
+
+
+# ---------------------------------------------------------------------------
+# Frame IO helpers
+# ---------------------------------------------------------------------------
+
+def _read(files: list[Path]) -> pl.DataFrame | None:
+    frames = [pl.read_parquet(p) for p in files]
+    if not frames:
+        return None
+    return frames[0] if len(frames) == 1 else pl.concat(frames, how="diagonal_relaxed")
+
+
+def _ensure_cols(df: pl.DataFrame, names: Iterable[str]) -> pl.DataFrame:
+    missing = [pl.lit(None, dtype=pl.Utf8).alias(n) for n in names if n not in df.columns]
+    return df.with_columns(missing) if missing else df
+
+
+def _cs(col: str) -> pl.Expr:
+    return common.clean_str(col)
+
+
+# ---------------------------------------------------------------------------
+# Parent-transaction column re-derivation (must match flat_txns.py exactly).
+# ---------------------------------------------------------------------------
+
+def _transaction_date_expr(date_col: str) -> pl.Expr:
+    return common.builder_date(date_col).fill_null(common.builder_date("receivedDt"))
+
+
+# ---------------------------------------------------------------------------
+# Id-maps read back from the already-written tables (parameterized core select).
+# ---------------------------------------------------------------------------
+
+def _entity_id_map(session, state_id: int) -> pl.DataFrame:
+    """Read entity id-map for the state's entities.
+
+    Person/org entities join on (entity_type, normalized_name); committee entities
+    join on their natural ``committee_id`` (= committee filer_id), NOT on name —
+    the ORM resolves the recipient/payer via ``committee.entity`` (found by
+    filer_id), so per-row filerName variants must all map to the single committee
+    entity. entity_type is stored as the enum NAME ("PERSON"/"ORGANIZATION"/
+    "COMMITTEE"); a "" normalized_name is stored as NULL by the ORM (coalesced to
+    "" here for join parity).
+    """
+    stmt = select(
+        UnifiedEntity.id,
+        UnifiedEntity.entity_type,
+        UnifiedEntity.normalized_name,
+        UnifiedEntity.committee_id,
+    ).where(UnifiedEntity.state_id == state_id)
+    rows = session.execute(stmt).all()
+    return pl.DataFrame(
+        {
+            "_ent_id": [r[0] for r in rows],
+            # SQLAlchemy hands back the Enum member; take its .name for the stored form.
+            "_ent_type": [getattr(r[1], "name", r[1]) for r in rows],
+            # ORM stores "" normalized_name as NULL -> coalesce to "" for join parity.
+            "_ent_norm": [(r[2] if r[2] is not None else "") for r in rows],
+            "_ent_committee_id": [r[3] for r in rows],
+        },
+        schema={
+            "_ent_id": pl.Int64, "_ent_type": pl.Utf8, "_ent_norm": pl.Utf8,
+            "_ent_committee_id": pl.Utf8,
+        },
+    )
+
+
+def _person_id_map(session, state_id: int) -> pl.DataFrame:
+    """Read persons keyed by (lower first, lower last, lower org), and ALSO carry
+    each person's entity key (entity_type, normalized_name) derived from the
+    person's STORED name (incl. middle/suffix the dim layer backfilled).
+
+    The party (contributor/payee) entity is linked via this STORED entity key —
+    not the source row's recomputed name — so a person whose suffix/middle differs
+    across source rows still resolves to the single entity dims built from their
+    first occurrence (matching the ORM, which links via the person object).
+    """
+    rows = session.execute(
+        select(
+            UnifiedPerson.id,
+            UnifiedPerson.first_name,
+            UnifiedPerson.middle_name,
+            UnifiedPerson.last_name,
+            UnifiedPerson.suffix,
+            UnifiedPerson.organization,
+        ).where(UnifiedPerson.state_id == state_id)
+    ).all()
+
+    def _lower_or_null(v):
+        return v.strip().lower() if isinstance(v, str) and v.strip() else None
+
+    return pl.DataFrame(
+        {
+            "_pid": [r[0] for r in rows],
+            "_pk_fn": [_lower_or_null(r[1]) for r in rows],
+            "_pk_ln": [_lower_or_null(r[3]) for r in rows],
+            "_pk_org": [_lower_or_null(r[5]) for r in rows],
+            "first_name": [r[1] for r in rows],
+            "middle_name": [r[2] for r in rows],
+            "last_name": [r[3] for r in rows],
+            "suffix": [r[4] for r in rows],
+            "organization": [r[5] for r in rows],
+        },
+        schema={
+            "_pid": pl.Int64, "_pk_fn": pl.Utf8, "_pk_ln": pl.Utf8, "_pk_org": pl.Utf8,
+            "first_name": pl.Utf8, "middle_name": pl.Utf8, "last_name": pl.Utf8,
+            "suffix": pl.Utf8, "organization": pl.Utf8,
+        },
+    ).with_columns(
+        pl.when(_cs("organization").is_not_null())
+        .then(pl.lit("ORGANIZATION"))
+        .otherwise(pl.lit("PERSON"))
+        .alias("_party_ent_type"),
+        _norm_name_expr_from(
+            pl.when(_cs("organization").is_not_null())
+            .then(_cs("organization"))
+            .otherwise(
+                common.full_name_expr(
+                    "first_name", "middle_name", "last_name", "suffix", "organization"
+                )
+            )
+        ).alias("_party_ent_norm"),
+    ).select(
+        ["_pid", "_pk_fn", "_pk_ln", "_pk_org", "_party_ent_type", "_party_ent_norm"]
+    )
+
+
+def _transaction_id_map(session, state_id: int, transaction_type: str) -> pl.DataFrame:
+    """Read transaction_id (natural) -> id for one (state, transaction_type)."""
+    stmt = select(
+        UnifiedTransaction.id,
+        UnifiedTransaction.transaction_id,
+    ).where(
+        UnifiedTransaction.state_id == state_id,
+        UnifiedTransaction.transaction_type == transaction_type,
+    )
+    rows = session.execute(stmt).all()
+    return pl.DataFrame(
+        {
+            "_txn_id": [r[0] for r in rows],
+            "_txn_nat": [(None if r[1] is None else str(r[1])) for r in rows],
+        },
+        schema={"_txn_id": pl.Int64, "_txn_nat": pl.Utf8},
+    )
+
+
+def _address_id_map(session, state_id: int) -> pl.DataFrame:
+    """Read (lower street_1, lower city, lower state, zip) -> id for addresses.
+
+    Mirrors the dims address dedup key (``_address_dedup``) — addresses are not
+    state-scoped (the model has no per-row state_id used in the key), so all rows
+    are read. The 4-field natural key matches the ORM's ``_find_address_by_fields``
+    case-insensitive lookup (street_1/city/state lowered, zip as-is).
+    """
+    from app.core.models import UnifiedAddress
+
+    stmt = select(
+        UnifiedAddress.id,
+        UnifiedAddress.street_1,
+        UnifiedAddress.city,
+        UnifiedAddress.state,
+        UnifiedAddress.zip_code,
+    )
+    rows = session.execute(stmt).all()
+
+    def _low(v):
+        return v.lower() if isinstance(v, str) else None
+
+    return pl.DataFrame(
+        {
+            "_aid": [r[0] for r in rows],
+            "_ak_s1": [_low(r[1]) for r in rows],
+            "_ak_city": [_low(r[2]) for r in rows],
+            "_ak_state": [_low(r[3]) for r in rows],
+            "_ak_zip": [r[4] for r in rows],
+        },
+        schema={
+            "_aid": pl.Int64, "_ak_s1": pl.Utf8, "_ak_city": pl.Utf8,
+            "_ak_state": pl.Utf8, "_ak_zip": pl.Utf8,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dim-FK retrofit (person.address_id, entity.person_id, entity.address_id).
+#
+# The dim family writes persons/entities/addresses as independent frames without
+# surrogate linkage. The ORM links entity -> person -> address (and entity ->
+# address). Under resolve_fks=True the gate verifies that linkage, so this family
+# retrofits those FKs by real id-joins: each person takes the address from its
+# FIRST occurrence (RCPT before EXPN, in id order); each PERSON/ORGANIZATION entity
+# takes the person (and that person's address) from the FIRST person that created
+# the entity's normalized name. COMMITTEE entities get no person and no address
+# (RCPT/EXPN carry no committee street columns).
+# ---------------------------------------------------------------------------
+
+# A large offset added to EXPN sort keys so EXPN persons sort AFTER all RCPT
+# persons (mirrors flat_txns_dims load order; RCPT priority 10 < EXPN within file).
+_EXPN_SORT_OFFSET = 1_000_000_000_000
+
+
+def _person_addr_keys(
+    df: pl.DataFrame,
+    *,
+    org_col: str,
+    first_col: str,
+    last_col: str,
+    suffix_col: str,
+    s1_col: str | None,
+    city_col: str,
+    state_col: str,
+    zip_col: str,
+    id_col: str,
+    sort_offset: int,
+) -> pl.DataFrame:
+    """Project per-row person key + address key + entity key + load-order sort key.
+
+    Address fields mirror flat_txns_dims._address_frame_* (RCPT has no street_1).
+    Entity key mirrors flat_txns_dims._build_entities_from_persons: entity_type is
+    ORGANIZATION when org present else PERSON; entity name = org else full_name;
+    normalized via normalize_entity_name.
+    """
+    s1 = (
+        _cs(s1_col).str.to_lowercase()
+        if s1_col is not None
+        else pl.lit(None, dtype=pl.Utf8)
+    )
+    full_name = common.full_name_expr(
+        first_col, "person_middle_name", last_col, suffix_col, org_col
+    )
+    org = _cs(org_col)
+    ent_name = pl.when(org.is_not_null()).then(org).otherwise(full_name)
+    ent_type = pl.when(org.is_not_null()).then(pl.lit("ORGANIZATION")).otherwise(pl.lit("PERSON"))
+    return df.with_columns(
+        _cs(org_col).str.to_lowercase().alias("_pk_org"),
+        _cs(first_col).str.to_lowercase().alias("_pk_fn"),
+        _cs(last_col).str.to_lowercase().alias("_pk_ln"),
+        s1.alias("_ak_s1"),
+        _cs(city_col).str.to_lowercase().alias("_ak_city"),
+        common.upper_str(state_col).str.to_lowercase().alias("_ak_state"),
+        _cs(zip_col).alias("_ak_zip"),
+        (pl.col(id_col).cast(pl.Int64) + sort_offset).alias("_sort_key"),
+        # full_name length gates whether a person exists at all (ORM build_person).
+        full_name.str.len_chars().alias("_full_len"),
+        ent_type.alias("_ent_type"),
+        _norm_name_expr_from(ent_name).alias("_ent_norm"),
+    ).select(
+        ["_pk_org", "_pk_fn", "_pk_ln", "_ak_s1", "_ak_city", "_ak_state",
+         "_ak_zip", "_sort_key", "_full_len", "_ent_type", "_ent_norm"]
+    )
+
+
+def _first_per_person(rows: pl.DataFrame) -> pl.DataFrame:
+    """First occurrence per (org, fn, ln) by ascending sort key (load order)."""
+    return (
+        rows.filter(pl.col("_full_len") > 0)
+        .sort("_sort_key")
+        .unique(subset=["_pk_org", "_pk_fn", "_pk_ln"], keep="first", maintain_order=True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-row participant projection (one frame: txn natural key + person/entity keys).
+# ---------------------------------------------------------------------------
+
+def _project_rcpt(df: pl.DataFrame) -> pl.DataFrame:
+    """RCPT -> one row per source record with join keys + parent-txn fields.
+
+    A participant person exists when name.full_name is non-empty (mirrors
+    build_person -> None on empty name). The contributor entity is PERSON (full
+    name) or ORGANIZATION (org name).
+    """
+    org = _cs("contributorNameOrganization")
+    first = _cs("contributorNameFirst")
+    last = _cs("contributorNameLast")
+    full_name = common.full_name_expr(
+        "contributorNameFirst", "person_middle_name", "contributorNameLast",
+        "contributorNameSuffixCd", "contributorNameOrganization",
+    )
+    return df.with_columns(
+        pl.lit(None, dtype=pl.Utf8).alias("person_middle_name"),
+    ).with_columns(
+        # parent-txn natural key
+        pl.col("contributionInfoId").cast(pl.Utf8).alias("_txn_nat"),
+        # parent-txn copied fields (must match flat_txns.py)
+        common.builder_amount("contributionAmount").alias("amount"),
+        _transaction_date_expr("contributionDt").alias("txn_date"),
+        pl.col("contributionDescr").cast(pl.Utf8).alias("description"),
+        # committee (recipient/payer) natural key — joined by filer_id, not name.
+        _cs("filerIdent").alias("_filer_id"),
+        # participant person key (the participant entity is resolved from the
+        # STORED person row via _person_id_map, not recomputed here).
+        first.str.to_lowercase().alias("_pk_fn"),
+        last.str.to_lowercase().alias("_pk_ln"),
+        org.str.to_lowercase().alias("_pk_org"),
+        full_name.str.len_chars().alias("_full_len"),
+    )
+
+
+def _project_expn(df: pl.DataFrame) -> pl.DataFrame:
+    """EXPN -> one row per source record with join keys + parent-txn fields."""
+    org = _cs("payeeNameOrganization")
+    first = _cs("payeeNameFirst")
+    last = _cs("payeeNameLast")
+    full_name = common.full_name_expr(
+        "payeeNameFirst", "person_middle_name", "payeeNameLast",
+        "payeeNameSuffixCd", "payeeNameOrganization",
+    )
+    return df.with_columns(
+        pl.lit(None, dtype=pl.Utf8).alias("person_middle_name"),
+    ).with_columns(
+        pl.col("expendInfoId").cast(pl.Utf8).alias("_txn_nat"),
+        common.builder_amount("expendAmount").alias("amount"),
+        _transaction_date_expr("expendDt").alias("txn_date"),
+        pl.col("expendDescr").cast(pl.Utf8).alias("description"),
+        # committee (recipient/payer) natural key — joined by filer_id, not name.
+        _cs("filerIdent").alias("_filer_id"),
+        first.str.to_lowercase().alias("_pk_fn"),
+        last.str.to_lowercase().alias("_pk_ln"),
+        org.str.to_lowercase().alias("_pk_org"),
+        full_name.str.len_chars().alias("_full_len"),
+    )
+
+
+def _norm_name_expr_from(name_expr: pl.Expr) -> pl.Expr:
+    """normalize_entity_name applied to an arbitrary string expression."""
+    s = name_expr.cast(pl.Utf8).str.strip_chars().str.to_lowercase()
+    s = s.str.replace_all(r"[^a-z0-9]+", " ").str.replace_all(r"\s+", " ").str.strip_chars()
+    return s.fill_null("")
+
+
+# ---------------------------------------------------------------------------
+# Join helpers
+# ---------------------------------------------------------------------------
+
+def _attach_party_person(proj: pl.DataFrame, person_map: pl.DataFrame) -> pl.DataFrame:
+    """Attach the participant person id (and a built flag) via the name key.
+
+    Persons are deduped to (org, fn, ln) within the state; orgs key on org alone
+    (fn/ln null), individuals on (fn, ln) with org null — exactly how
+    _person_id_map keys the read-back rows.
+    """
+    return proj.join(
+        person_map, on=["_pk_fn", "_pk_ln", "_pk_org"], how="left", join_nulls=True
+    )
+
+
+def _attach_party_entity(proj: pl.DataFrame, entity_map: pl.DataFrame) -> pl.DataFrame:
+    """Attach the participant (contributor/payee) entity id via (type, norm name).
+
+    Only PERSON/ORGANIZATION entities are candidates — a participant is never a
+    committee — so committee rows are excluded to avoid a normalized-name collision
+    between a committee entity and a same-named org participant.
+    """
+    party = (
+        entity_map.filter(pl.col("_ent_type") != "COMMITTEE")
+        .select(["_ent_id", "_ent_type", "_ent_norm"])
+        .rename({"_ent_id": "_party_ent_id"})
+    )
+    return proj.join(
+        party,
+        left_on=["_party_ent_type", "_party_ent_norm"],
+        right_on=["_ent_type", "_ent_norm"],
+        how="left",
+    )
+
+
+def _attach_committee_entity(proj: pl.DataFrame, entity_map: pl.DataFrame) -> pl.DataFrame:
+    """Attach the committee entity id via the committee's natural filer_id.
+
+    The ORM links recipient/payer to ``committee.entity`` (the committee is found
+    by filer_id), so per-row filerName variants all resolve to the one committee
+    entity for that filer.
+    """
+    comm = (
+        entity_map.filter(
+            (pl.col("_ent_type") == "COMMITTEE") & pl.col("_ent_committee_id").is_not_null()
+        )
+        .select(["_ent_id", "_ent_committee_id"])
+        .rename({"_ent_id": "_committee_ent_id"})
+    )
+    return proj.join(
+        comm,
+        left_on="_filer_id",
+        right_on="_ent_committee_id",
+        how="left",
+    )
+
+
+def _attach_txn(proj: pl.DataFrame, txn_map: pl.DataFrame) -> pl.DataFrame:
+    return proj.join(txn_map, on="_txn_nat", how="left")
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+class FlatTxnsDetailWorker:
+    """Detail/junction rows for RCPT/EXPN with real surrogate-id linkage."""
+
+    record_types = frozenset({"RCPT", "EXPN"})
+    priority = 11  # after flat_txns_dims (9) and flat_txns (10)
+
+    def run(self, files_by_type: dict[str, list[Path]], ctx: FamilyContext) -> dict[str, int]:
+        rcpt = _read(files_by_type.get("RCPT", []))
+        expn = _read(files_by_type.get("EXPN", []))
+        if rcpt is not None:
+            rcpt = _ensure_cols(rcpt, _RCPT_COLS)
+        if expn is not None:
+            expn = _ensure_cols(expn, _EXPN_COLS)
+
+        # Id-maps from the already-populated dim + transaction tables.
+        entity_map = _entity_id_map(ctx.session, ctx.state_id)
+        person_map = _person_id_map(ctx.session, ctx.state_id)
+
+        counts: dict[str, int] = {}
+
+        if rcpt is not None and rcpt.height > 0:
+            txn_map = _transaction_id_map(ctx.session, ctx.state_id, "CONTRIBUTION")
+            proj = _project_rcpt(rcpt)
+            proj = _attach_txn(proj, txn_map)
+            proj = _attach_party_person(proj, person_map)
+            proj = _attach_party_entity(proj, entity_map)
+            proj = _attach_committee_entity(proj, entity_map)
+            counts["contributions"] = self._write_contributions(proj, ctx)
+            counts["txn_persons_rcpt"] = self._write_txn_persons(
+                proj, ctx, role="CONTRIBUTOR"
+            )
+
+        if expn is not None and expn.height > 0:
+            txn_map = _transaction_id_map(ctx.session, ctx.state_id, "EXPENDITURE")
+            proj = _project_expn(expn)
+            proj = _attach_txn(proj, txn_map)
+            proj = _attach_party_person(proj, person_map)
+            proj = _attach_party_entity(proj, entity_map)
+            proj = _attach_committee_entity(proj, entity_map)
+            counts["expenditures"] = self._write_expenditures(proj, ctx)
+            counts["txn_persons_expn"] = self._write_txn_persons(
+                proj, ctx, role="PAYEE"
+            )
+
+        # Retrofit dim-layer FKs (person.address_id, entity.person_id,
+        # entity.address_id) that flat_txns_dims left unset — verified under
+        # resolve_fks=True.
+        self._retrofit_dim_fks(rcpt, expn, ctx)
+
+        loaded = sum(counts.values())
+        _logger.info(f"[vectorized.flat_txns_detail] loaded {loaded} detail rows: {counts}")
+        return {"loaded": loaded, **counts}
+
+    # -- dim-FK retrofit ----------------------------------------------------
+
+    def _retrofit_dim_fks(
+        self,
+        rcpt: pl.DataFrame | None,
+        expn: pl.DataFrame | None,
+        ctx: FamilyContext,
+    ) -> None:
+        """Set person.address_id, entity.person_id, entity.address_id via id-joins.
+
+        Each person takes the address of its FIRST occurrence (RCPT before EXPN);
+        each PERSON/ORGANIZATION entity takes the FIRST person (and that person's
+        address) that created its normalized name. All ids come from the already
+        -written dim tables (no surrogate guessing). Updates are parameterized core
+        statements (``bindparam`` + ``.values``), never string SQL.
+        """
+        person_map = _person_id_map(ctx.session, ctx.state_id)
+        addr_map = _address_id_map(ctx.session, ctx.state_id)
+        entity_map = _entity_id_map(ctx.session, ctx.state_id)
+
+        # 1. Per-person first-occurrence address key (load order: RCPT then EXPN).
+        per_row_parts: list[pl.DataFrame] = []
+        if rcpt is not None and rcpt.height > 0:
+            r = rcpt.with_columns(
+                pl.lit(None, dtype=pl.Utf8).alias("person_middle_name"),
+            )
+            per_row_parts.append(
+                _person_addr_keys(
+                    r, org_col="contributorNameOrganization",
+                    first_col="contributorNameFirst", last_col="contributorNameLast",
+                    suffix_col="contributorNameSuffixCd",
+                    s1_col=None, city_col="contributorStreetCity",
+                    state_col="contributorStreetStateCd",
+                    zip_col="contributorStreetPostalCode",
+                    id_col="contributionInfoId", sort_offset=0,
+                )
+            )
+        if expn is not None and expn.height > 0:
+            e = expn.with_columns(
+                pl.lit(None, dtype=pl.Utf8).alias("person_middle_name"),
+            )
+            per_row_parts.append(
+                _person_addr_keys(
+                    e, org_col="payeeNameOrganization",
+                    first_col="payeeNameFirst", last_col="payeeNameLast",
+                    suffix_col="payeeNameSuffixCd",
+                    s1_col="payeeStreetAddr1", city_col="payeeStreetCity",
+                    state_col="payeeStreetStateCd",
+                    zip_col="payeeStreetPostalCode",
+                    id_col="expendInfoId", sort_offset=_EXPN_SORT_OFFSET,
+                )
+            )
+        if not per_row_parts:
+            return
+
+        per_row = pl.concat(per_row_parts, how="diagonal_relaxed")
+        first = _first_per_person(per_row)
+
+        # Attach person id and address id to each first-occurrence person.
+        first = first.join(
+            person_map, on=["_pk_fn", "_pk_ln", "_pk_org"], how="left", join_nulls=True
+        )
+        first = first.join(
+            addr_map, on=["_ak_s1", "_ak_city", "_ak_state", "_ak_zip"],
+            how="left", join_nulls=True,
+        )
+
+        # 2. person.address_id update set (persons with a resolved address).
+        person_addr = (
+            first.filter(pl.col("_pid").is_not_null() & pl.col("_aid").is_not_null())
+            .select(pl.col("_pid").alias("pid"), pl.col("_aid").alias("aid"))
+        )
+        self._apply_person_address(ctx.session, person_addr)
+
+        # 3. entity.person_id / entity.address_id: the entity's representative person
+        #    is the FIRST person (by sort key) with that entity's normalized name.
+        #    `first` already carries _ent_type / _ent_norm from _person_addr_keys.
+        entity_rep = self._entity_representatives(first)
+        entity_rep = entity_rep.join(
+            entity_map.filter(pl.col("_ent_type") != "COMMITTEE"),
+            on=["_ent_type", "_ent_norm"], how="left",
+        )
+        ent_updates = entity_rep.filter(pl.col("_ent_id").is_not_null()).select(
+            pl.col("_ent_id").alias("eid"),
+            pl.col("_pid").alias("pid"),
+            pl.col("_aid").alias("aid"),
+        )
+        self._apply_entity_links(ctx.session, ent_updates)
+
+    @staticmethod
+    def _entity_representatives(first: pl.DataFrame) -> pl.DataFrame:
+        """Per (entity_type, normalized entity name): the FIRST person (min sort key)
+        and that person's address.
+
+        The entity is created by the first build_person call for a normalized name,
+        which sets the entity's ``name`` AND ``address`` (the dims family already
+        wrote ``name``/``normalized_name`` from this same first person). We link
+        ``person_id``/``address_id`` to that same first person so the vec graph is
+        internally consistent with the entity row dims already wrote.
+
+        NOTE: the ORM additionally REASSIGNS ``entity.person`` via
+        ``person.entity = entity`` on later same-normalized-name persons, and that
+        reassignment is FLUSH-ORDER dependent — the ORM is non-deterministic here
+        (ORM-vs-ORM differs run to run). The test canonicalizes this single
+        non-deterministic nested field so the rest of the linkage is gated strictly.
+        """
+        present = first.filter(pl.col("_pid").is_not_null())
+        return (
+            present.sort("_sort_key")
+            .unique(subset=["_ent_type", "_ent_norm"], keep="first", maintain_order=True)
+            .select(["_ent_type", "_ent_norm", "_pid", "_aid"])
+        )
+
+    @staticmethod
+    def _apply_person_address(session, frame: pl.DataFrame) -> None:
+        from sqlalchemy import bindparam, update
+
+        if frame.is_empty():
+            return
+        stmt = (
+            update(UnifiedPerson.__table__)
+            .where(UnifiedPerson.__table__.c.id == bindparam("b_pid"))
+            .values(address_id=bindparam("b_aid"))
+        )
+        params = [{"b_pid": r["pid"], "b_aid": r["aid"]} for r in frame.to_dicts()]
+        session.connection().execute(stmt, params)
+        session.commit()
+
+    @staticmethod
+    def _apply_entity_links(session, frame: pl.DataFrame) -> None:
+        from sqlalchemy import bindparam, update
+
+        if frame.is_empty():
+            return
+        stmt = (
+            update(UnifiedEntity.__table__)
+            .where(UnifiedEntity.__table__.c.id == bindparam("b_eid"))
+            .values(person_id=bindparam("b_pid"), address_id=bindparam("b_aid"))
+        )
+        params = [
+            {"b_eid": r["eid"], "b_pid": r["pid"], "b_aid": r["aid"]}
+            for r in frame.to_dicts()
+        ]
+        session.connection().execute(stmt, params)
+        session.commit()
+
+    # -- contributions ------------------------------------------------------
+
+    def _write_contributions(self, proj: pl.DataFrame, ctx: FamilyContext) -> int:
+        """One UnifiedContribution per RCPT row that has BOTH a contributor entity
+        and a recipient (committee) entity, and a resolved parent transaction.
+
+        Mirrors _build_contribution_detail: skip when contributor_entity OR
+        recipient_entity is missing.
+        """
+        rows = (
+            proj.filter(
+                pl.col("_txn_id").is_not_null()
+                & pl.col("_party_ent_id").is_not_null()
+                & pl.col("_committee_ent_id").is_not_null()
+            )
+            .unique(subset=["_txn_id"], keep="first", maintain_order=True)
+            .select(
+                pl.col("_txn_id").alias("transaction_id"),
+                pl.col("_party_ent_id").alias("contributor_entity_id"),
+                pl.col("_committee_ent_id").alias("recipient_entity_id"),
+                pl.lit(ctx.state_id).alias("state_id"),
+                pl.col("amount"),
+                pl.col("txn_date").alias("receipt_date"),
+                pl.lit(None, dtype=pl.Utf8).alias("contribution_type"),
+                pl.lit(False).alias("is_anonymous"),
+                pl.col("description"),
+            )
+        )
+        return common.write_frame(ctx.session, UnifiedContribution, rows, conflict_cols=None)
+
+    # -- expenditures -------------------------------------------------------
+
+    def _write_expenditures(self, proj: pl.DataFrame, ctx: FamilyContext) -> int:
+        """One UnifiedExpenditure per EXPN row with BOTH a payer (committee) entity
+        and a payee entity, and a resolved parent transaction.
+
+        Mirrors _build_expenditure_detail: payer = committee.entity, payee = payee
+        entity; skip when either is missing.
+        """
+        rows = (
+            proj.filter(
+                pl.col("_txn_id").is_not_null()
+                & pl.col("_party_ent_id").is_not_null()
+                & pl.col("_committee_ent_id").is_not_null()
+            )
+            .unique(subset=["_txn_id"], keep="first", maintain_order=True)
+            .select(
+                pl.col("_txn_id").alias("transaction_id"),
+                pl.col("_committee_ent_id").alias("payer_entity_id"),
+                pl.col("_party_ent_id").alias("payee_entity_id"),
+                pl.lit(ctx.state_id).alias("state_id"),
+                pl.col("amount"),
+                pl.col("txn_date").alias("expenditure_date"),
+                pl.lit(None, dtype=pl.Utf8).alias("expenditure_type"),
+                pl.col("description"),
+            )
+        )
+        return common.write_frame(ctx.session, UnifiedExpenditure, rows, conflict_cols=None)
+
+    # -- transaction_persons ------------------------------------------------
+
+    def _write_txn_persons(self, proj: pl.DataFrame, ctx: FamilyContext, *, role: str) -> int:
+        """One junction row per source row that built a participant person.
+
+        Mirrors _attach_transaction_persons: emit only when the participant person
+        exists (person_id resolved); ``entity_id = person.entity.id`` (the
+        participant entity). RECIPIENT is never emitted (RCPT builds CONTRIBUTOR,
+        EXPN builds PAYEE — there is no RECIPIENT participant here).
+
+        Deduped on (transaction_id, person_id, role): the ORM appends one row per
+        processed record, but repeats of the same (txn, person, role) collapse —
+        and within one RCPT/EXPN row there is exactly one participant, so this only
+        guards against the (rare) case where two source rows share a transaction id.
+        """
+        rows = (
+            proj.filter(
+                pl.col("_txn_id").is_not_null()
+                & pl.col("_pid").is_not_null()
+                & (pl.col("_full_len") > 0)
+            )
+            .with_columns(pl.lit(role).alias("role"))
+            .unique(subset=["_txn_id", "_pid", "role"], keep="first", maintain_order=True)
+            .select(
+                pl.col("_txn_id").alias("transaction_id"),
+                pl.col("_pid").alias("person_id"),
+                pl.col("_party_ent_id").alias("entity_id"),
+                pl.lit(ctx.state_id).alias("state_id"),
+                pl.lit(None, dtype=pl.Int64).alias("committee_person_id"),
+                pl.col("role"),
+                pl.lit(None, dtype=pl.Decimal(38, 4)).alias("amount"),
+                pl.lit(None, dtype=pl.Utf8).alias("notes"),
+            )
+        )
+        return common.write_frame(
+            ctx.session, UnifiedTransactionPerson, rows, conflict_cols=None
+        )
+
+
+register(FlatTxnsDetailWorker())

--- a/tests/ingest_equivalence/test_flat_txns_detail_family.py
+++ b/tests/ingest_equivalence/test_flat_txns_detail_family.py
@@ -1,0 +1,179 @@
+"""Gate: the vectorized flat_txns DETAIL/JUNCTION family == the ORM loader.
+
+Loads ONLY the RCPT (contribs_golden) and EXPN (expend_golden) fixtures via both
+the ORM loader and ``run_vectorized`` (all flat_txns families registered), then
+asserts ``diff_snapshots`` restricted to the detail/junction tables is empty —
+with ``resolve_fks=True`` so the entity/person LINKAGE this family builds (not
+just row counts) is what gets verified.
+
+Mirrors ``test_flat_txns_family``: ``_make_engine(enforce_fk=...)``, the
+ORM-load-subset pattern, and the single-fixture-dir trick that points discovery
+at a directory containing ONLY the two parquet files.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from app.core.ingest_equivalence import diff_snapshots, snapshot_unified
+from app.core.ingest_vectorized import run_vectorized
+from tests.ingest_equivalence.test_harness import FIXTURES, _make_engine
+
+# ---------------------------------------------------------------------------
+# Canonicalize the ONE non-deterministic linkage in resolve_fks output.
+#
+# When two source rows describe the SAME party with trivial spelling variants
+# ("CARL F" vs "CARL F.", "U S Treasury" vs "U.S. Treasury"), the dim layer keeps
+# both person rows (they have distinct natural keys) but they share ONE entity
+# (same normalized_name). The ORM links that entity to ONE of the variants via
+# ``person.entity = entity`` — a reassignment whose winner is FLUSH / HASH-SEED
+# ordering dependent: ORM-vs-ORM itself diverges run to run under resolve_fks=True
+# (verified). The entity's IDENTITY (entity_type, name, normalized_name) and its
+# OWN resolved address are deterministic and ARE compared; only the specific
+# person VARIANT an entity points to is not. So we blank the ``person_id``
+# resolved INSIDE an entity (the representative person) on BOTH sides.
+#
+# Crucially this does NOT touch the junction's DIRECT ``person_id`` (the actual
+# participant person this family links) — that is deterministic and stays under
+# strict comparison.
+# ---------------------------------------------------------------------------
+
+
+def _canon_node(node: Any, *, inside_entity: bool = False) -> Any:
+    if isinstance(node, dict):
+        is_entity = "entity_type" in node and "normalized_name" in node
+        out: dict[str, Any] = {}
+        for k, v in node.items():
+            if is_entity and k == "person_id":
+                # Representative person of an entity — non-deterministic; blank it
+                # but keep a marker so "has a person" vs "None" is still compared.
+                out[k] = "<entity-person>" if v is not None else None
+            else:
+                out[k] = _canon_node(v, inside_entity=inside_entity or is_entity)
+        return out
+    if isinstance(node, str):
+        stripped = node.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (ValueError, SyntaxError):
+                return node
+            return repr(_canon_node(parsed, inside_entity=inside_entity))
+        return node
+    return node
+
+
+def _canon_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [{k: _canon_node(v) for k, v in r.items()} for r in rows]
+
+_FLAT_TXN_RECORD_TYPES = frozenset({"RCPT", "EXPN"})
+_FLAT_TXN_FILENAMES = frozenset({"contribs_golden.parquet", "expend_golden.parquet"})
+
+# Detail/junction tables this family brings to real (linkage-resolved) parity.
+TABLES = (
+    "unified_contributions",
+    "unified_expenditures",
+    "unified_transaction_persons",
+)
+
+
+def _load_golden_rcpt_expn(engine) -> None:
+    """ORM-load ONLY the RCPT and EXPN golden fixtures (FK parents not seeded)."""
+    from sqlmodel import Session
+
+    from app.core.load_cache import BuilderCache
+    from scripts.loaders import production_loader as P
+    from scripts.loaders.file_discovery import discover_state_files
+    from scripts.loaders.loader_config import LoaderConfig
+
+    session = Session(engine, expire_on_commit=False)
+    try:
+        P._ensure_committee_types(session)
+        state = P._ensure_state(session, "texas")
+        cache = BuilderCache()
+        cfg = LoaderConfig(batch_size=1000, commit_frequency=1000)
+        discovered = sorted(
+            (
+                (item.path, item.record_type)
+                for item in discover_state_files("texas", base_dir=FIXTURES)
+                if item.record_type in _FLAT_TXN_RECORD_TYPES
+            ),
+            key=lambda p_rt: (P._FILE_PRIORITY.get(p_rt[1] or "", 50), str(p_rt[0])),
+        )
+        assert discovered, "no RCPT/EXPN golden fixtures discovered"
+        for path, rtype in discovered:
+            _n, _rej, cache = P._load_file(
+                path,
+                rtype,
+                cfg,
+                state="texas",
+                state_id=state.id,
+                state_code=state.code,
+                session=session,
+                cache=cache,
+                max_remaining=None,
+            )
+        session.commit()
+    finally:
+        session.close()
+
+
+def _make_rcpt_expn_fixtures_dir(tmp_path: Path) -> Path:
+    """Copy only contribs/expend golden parquets into a sub-dir for discovery."""
+    import shutil
+
+    sub = tmp_path / "flat_only"
+    sub.mkdir()
+    for name in _FLAT_TXN_FILENAMES:
+        shutil.copy2(FIXTURES / name, sub / name)
+    return sub
+
+
+def test_flat_txns_detail_family_matches_orm(tmp_path: Path):
+    """contributions / expenditures / transaction_persons must be row-for-row equal
+    to the ORM loader, with surrogate FKs RESOLVED to parent natural keys.
+
+    resolve_fks=True is what verifies the entity/person linkage (contributor,
+    recipient/payer, payee, junction person+entity) — not just row counts.
+    """
+    orm_engine = _make_engine(tmp_path / "orm_detail.db", enforce_fk=False)
+    _load_golden_rcpt_expn(orm_engine)
+
+    flat_fixtures = _make_rcpt_expn_fixtures_dir(tmp_path)
+    vec_engine = _make_engine(tmp_path / "vec_detail.db", enforce_fk=False)
+    run_vectorized(vec_engine, flat_fixtures)
+
+    orm_full = snapshot_unified(orm_engine, resolve_fks=True)
+    vec_full = snapshot_unified(vec_engine, resolve_fks=True)
+
+    # Both sides must be non-empty in every detail/junction table (check before
+    # canonicalization so emptiness is caught directly).
+    for tbl in TABLES:
+        assert orm_full.get(tbl), f"ORM produced no {tbl} rows — fixture/loader problem"
+        assert vec_full.get(tbl), f"vectorized produced no {tbl} rows — family not running"
+
+    orm = {t: _canon_rows(orm_full.get(t, [])) for t in TABLES}
+    vec = {t: _canon_rows(vec_full.get(t, [])) for t in TABLES}
+
+    diffs = diff_snapshots(orm, vec)
+    assert diffs == [], "detail/junction tables diverge from ORM:\n" + "\n".join(diffs)
+
+
+def test_flat_txns_detail_contribution_present(tmp_path: Path):
+    """RCPT fixture must produce at least one linked contribution."""
+    flat_fixtures = _make_rcpt_expn_fixtures_dir(tmp_path)
+    vec_engine = _make_engine(tmp_path / "vec.db", enforce_fk=False)
+    run_vectorized(vec_engine, flat_fixtures)
+    snap = snapshot_unified(vec_engine)
+    assert snap.get("unified_contributions"), "expected contributions from RCPT fixture"
+
+
+def test_flat_txns_detail_expenditure_present(tmp_path: Path):
+    """EXPN fixture must produce at least one linked expenditure."""
+    flat_fixtures = _make_rcpt_expn_fixtures_dir(tmp_path)
+    vec_engine = _make_engine(tmp_path / "vec.db", enforce_fk=False)
+    run_vectorized(vec_engine, flat_fixtures)
+    snap = snapshot_unified(vec_engine)
+    assert snap.get("unified_expenditures"), "expected expenditures from EXPN fixture"


### PR DESCRIPTION
## What

Adds the **flat_txns detail/junction family** to the vectorized ingest engine:

- `app/core/ingest_vectorized/families/flat_txns_detail.py` (priority **11**, runs after `flat_txns_dims`=9 and `flat_txns`=10) producing:
  - `unified_contributions` (from RCPT)
  - `unified_expenditures` (from EXPN)
  - `unified_transaction_persons` (junction)
- Registered via `families/__init__.py` import.

All linkage FKs are filled by **real surrogate-id joins** against the already-written dim + transaction tables — id-maps read back with **parameterized SQLAlchemy core `select`** (no f-string SQL), attached with Polars joins. **Pure Polars column expressions only — no `map_elements` / `.apply`.**

## Linkage (mirrors ORM builders/processor exactly)

- Contribution requires contributor entity **and** recipient (committee) entity; expenditure requires payer (committee) **and** payee entity (matches `_build_contribution_detail` / `_build_expenditure_detail`).
- Recipient/payer committee entity resolved by committee **filer_id** (the ORM links `committee.entity`), so per-row `filerName` variants all map to the one committee entity.
- Party (contributor/payee) entity resolved from the **stored person identity** (so per-row suffix/middle variance can't drop the link — fix from code review).
- Junction: one row per built participant (RCPT→CONTRIBUTOR, EXPN→PAYEE), `entity_id = person.entity.id`; RECIPIENT excluded; `contribution_type`/`expenditure_type` unmapped → None; `is_anonymous` default.
- **Dim-FK retrofit**: sets `unified_persons.address_id`, `unified_entities.person_id`, `unified_entities.address_id` that the dim family left unset (needed for `resolve_fks=True`), via id-joins.

## Harness

`_snapshot_resolved` now keys rows by the table's own primary key (falls back to `id`) so a committee-bearing DB (`unified_committees` PK = `filer_id`, no `id`) can be snapshotted under `resolve_fks=True` instead of raising `NoSuchColumnError`. Backward compatible for `id`-PK tables.

## Gate

`tests/ingest_equivalence/test_flat_txns_detail_family.py`: ORM-loads the RCPT+EXPN golden fixtures and `run_vectorized` into separate engines, asserts `diff_snapshots` over the 3 detail/junction tables with **`resolve_fks=True` == `[]`**, both sides non-empty.

It canonicalizes exactly one non-deterministic field — *which* person-variant an entity's `person_id` points to (the ORM's `person.entity = entity` reassignment is flush/hash-seed dependent; **ORM-vs-ORM itself diverges run-to-run** under `resolve_fks=True`, verified). The entity identity (type/name/normalized_name), its resolved address, the junction's direct participant person, and all family-built linkage stay under strict comparison.

## Checks

- `uv run pytest tests/ingest_equivalence -q` → **34 passed** (31 prior + 3 new); stable across multiple `PYTHONHASHSEED` values.
- `grep -rnE "map_elements|\.apply\(" app/core/ingest_vectorized/families/flat_txns_detail.py` → empty.
- `uv run ruff check app/core/ingest_vectorized tests/ingest_equivalence` → clean.
- code-review run; the one finding (per-row name in entity link) fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)